### PR TITLE
refactor(ui): standardize create/edit forms on Sheet slideout

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -68,6 +68,7 @@ docker compose exec api uv run -- python manage.py seed_training
 - Formatter/Linter: Biome (`biome.json`)
 - React/Next conventions: App Router, server actions, `use client` where necessary
 - Shared code via workspace packages (`@frontend/ui`, `@frontend/types`)
+- Overlay UI (Sheet vs Dialog vs AlertDialog, standard form slideout): see [UI Conventions](./ui-conventions.md)
 
 ### Backend (Python)
 - Linter: Ruff (configured in `pyproject.toml`)

--- a/docs/ui-conventions.md
+++ b/docs/ui-conventions.md
@@ -1,0 +1,65 @@
+# UI Conventions
+
+House rules for overlay UI across all modules. New modules (and in-flight rewrites, once they land) should follow these by default.
+
+## Sheet vs Dialog vs AlertDialog
+
+| Component | Use for | Examples |
+|---|---|---|
+| `Sheet` (side="right") | **All create/edit data-entry forms.** Anything with inputs the user fills in and submits. | Create/edit tank, transaction, shift, flight, certification |
+| `Dialog` | Small read-only or pick-one interactions that are not data-entry forms. | Hour-detail popovers, command palette, quick info panels |
+| `AlertDialog` | Blocking confirmations of destructive/irreversible actions. | "Delete this tank?" |
+
+The slideout (`Sheet`) is the single house standard for create/edit UI. Do not introduce new `Dialog`-based forms.
+
+## Standard form slideout
+
+Import from `@frontend/ui/components/ui/sheet` (monorepo) and follow this skeleton:
+
+```tsx
+<Sheet open={open} onOpenChange={onOpenChange}>
+  <SheetContent
+    side="right"
+    className="flex w-full flex-col gap-0 p-0 sm:max-w-md"
+  >
+    <SheetHeader className="border-b border-border p-4">
+      <SheetTitle>{isEdit ? 'Edit Thing' : 'Create Thing'}</SheetTitle>
+      <SheetDescription>One-line summary of what this form does.</SheetDescription>
+    </SheetHeader>
+
+    <form onSubmit={handleSubmit} className="flex flex-1 flex-col overflow-hidden">
+      {/* scrollable body */}
+      <div className="flex-1 space-y-4 overflow-y-auto p-4">
+        {/* fields */}
+      </div>
+
+      {/* pinned footer */}
+      <SheetFooter className="flex-col gap-2 border-t border-border p-4 sm:flex-row sm:justify-end">
+        <Button type="button" variant="outline" onClick={close} className="w-full sm:w-auto">
+          Cancel
+        </Button>
+        <Button type="submit" className="w-full sm:w-auto">
+          {isEdit ? 'Update' : 'Create'}
+        </Button>
+      </SheetFooter>
+    </form>
+  </SheetContent>
+</Sheet>
+```
+
+### Rules
+
+- **Side**: always `side="right"`.
+- **Width**: `w-full sm:max-w-md` (448px) is the standard form width. Use `sm:max-w-xl` only for genuinely dense forms (many two-column rows); use `sm:max-w-[400px]` narrow variant only for compact property editors (see `parking/aircraft-sheet.tsx`).
+- **Layout**: `p-0 gap-0` on `SheetContent`; the header, body, and footer own their `p-4` padding. Header gets `border-b`, footer gets `border-t`. Body scrolls (`flex-1 overflow-y-auto`); header and footer stay pinned.
+- **Header**: always include both `SheetTitle` and `SheetDescription` (Radix logs an accessibility warning without a description). Title is "Edit X" / "Create X".
+- **Footer buttons**: right-aligned; `Cancel` (variant `outline`) then the primary submit button, in that order. Buttons are `w-full sm:w-auto` (stacked full-width on mobile). A destructive action (e.g. Delete on an edit form) goes on the far left: switch the footer to `sm:justify-between`.
+- **Behavior**: this is a UI-shell convention only — keep form state, validation, and submit logic exactly as you would in any form. Disable buttons while saving; show "Saving..." on the primary button.
+
+## Confirmations
+
+Keep destructive confirmations as `AlertDialog` (or `Dialog` where already in place) — do not migrate them to `Sheet`. A slideout implies a workspace; a confirmation is a blocking question.
+
+## Status (as of 2026-07)
+
+Migrated to the Sheet standard: `fuel-farm/tank-form-dialog.tsx`, `fuel-dispatch/transaction-form-dialog.tsx`, and `line-schedule/shift-form-dialog.tsx` (on the `worktree-truck-sheets` branch). Modules with in-flight rewrites (invoicing, equipment, users/roles, training, flight-operations) and the frozen parking module were intentionally left untouched and should adopt this convention when their rewrites land.

--- a/frontend/apps/web/components/fuel-dispatch/transaction-form-dialog.tsx
+++ b/frontend/apps/web/components/fuel-dispatch/transaction-form-dialog.tsx
@@ -6,12 +6,6 @@ import type {
   ProgressEnum
 } from '@frontend/types/api'
 import { Button } from '@frontend/ui/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle
-} from '@frontend/ui/components/ui/dialog'
 import { Input } from '@frontend/ui/components/ui/input'
 import { Label } from '@frontend/ui/components/ui/label'
 import {
@@ -21,6 +15,14 @@ import {
   SelectTrigger,
   SelectValue
 } from '@frontend/ui/components/ui/select'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle
+} from '@frontend/ui/components/ui/sheet'
 import { useEffect, useState } from 'react'
 import { useFlights } from '../../hooks/use-flights'
 
@@ -98,118 +100,140 @@ export function TransactionFormDialog({
   }, [formData.quantity_gallons, formData.quantity_lbs])
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex w-full flex-col gap-0 p-0 sm:max-w-md"
+      >
+        <SheetHeader className="border-b border-border p-4">
+          <SheetTitle>
             {transaction ? 'Edit Transaction' : 'Create Transaction'}
-          </DialogTitle>
-        </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="ticket_number">Ticket Number *</Label>
-            <Input
-              id="ticket_number"
-              value={formData.ticket_number}
-              onChange={(e) =>
-                setFormData({ ...formData, ticket_number: e.target.value })
-              }
-              required
-              placeholder="Enter ticket number"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="flight">Flight (Optional)</Label>
-            <Select
-              value={formData.flight?.toString() || 'none'}
-              onValueChange={(value) =>
-                setFormData({
-                  ...formData,
-                  flight: value === 'none' ? null : Number.parseInt(value)
-                })
-              }
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Select a flight" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">No flight assigned</SelectItem>
-                {flights.map((flight) => (
-                  <SelectItem key={flight.id} value={flight.id}>
-                    {flight.callSign ?? flight.tailNumber} - {flight.aircraftType}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
+          </SheetTitle>
+          <SheetDescription>
+            {transaction
+              ? 'Update the details for this fuel transaction.'
+              : 'Record a new fuel transaction.'}
+          </SheetDescription>
+        </SheetHeader>
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-1 flex-col overflow-hidden"
+        >
+          <div className="flex-1 space-y-4 overflow-y-auto p-4">
             <div className="space-y-2">
-              <Label htmlFor="quantity_gallons">Quantity (Gallons) *</Label>
+              <Label htmlFor="ticket_number">Ticket Number *</Label>
               <Input
-                id="quantity_gallons"
-                type="number"
-                step="0.01"
-                value={formData.quantity_gallons}
+                id="ticket_number"
+                value={formData.ticket_number}
                 onChange={(e) =>
-                  setFormData({ ...formData, quantity_gallons: e.target.value })
+                  setFormData({ ...formData, ticket_number: e.target.value })
                 }
                 required
-                placeholder="0.00"
+                placeholder="Enter ticket number"
               />
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="quantity_lbs">Quantity (Lbs) *</Label>
-              <Input
-                id="quantity_lbs"
-                type="number"
-                step="0.01"
-                value={formData.quantity_lbs}
-                onChange={(e) =>
-                  setFormData({ ...formData, quantity_lbs: e.target.value })
+              <Label htmlFor="flight">Flight (Optional)</Label>
+              <Select
+                value={formData.flight?.toString() || 'none'}
+                onValueChange={(value) =>
+                  setFormData({
+                    ...formData,
+                    flight: value === 'none' ? null : Number.parseInt(value)
+                  })
                 }
-                required
-                placeholder="0.00"
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a flight" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">No flight assigned</SelectItem>
+                  {flights.map((flight) => (
+                    <SelectItem key={flight.id} value={flight.id}>
+                      {flight.callSign ?? flight.tailNumber} -{' '}
+                      {flight.aircraftType}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="quantity_gallons">Quantity (Gallons) *</Label>
+                <Input
+                  id="quantity_gallons"
+                  type="number"
+                  step="0.01"
+                  value={formData.quantity_gallons}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      quantity_gallons: e.target.value
+                    })
+                  }
+                  required
+                  placeholder="0.00"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="quantity_lbs">Quantity (Lbs) *</Label>
+                <Input
+                  id="quantity_lbs"
+                  type="number"
+                  step="0.01"
+                  value={formData.quantity_lbs}
+                  onChange={(e) =>
+                    setFormData({ ...formData, quantity_lbs: e.target.value })
+                  }
+                  required
+                  placeholder="0.00"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="density">Density (lbs/gal)</Label>
+              <Input
+                id="density"
+                type="number"
+                step="0.0001"
+                value={formData.density}
+                onChange={(e) =>
+                  setFormData({ ...formData, density: e.target.value })
+                }
+                placeholder="Auto-calculated"
+                disabled
+                className="bg-muted"
               />
+              <p className="text-sm text-muted-foreground">
+                Density is automatically calculated from gallons and lbs
+              </p>
             </div>
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="density">Density (lbs/gal)</Label>
-            <Input
-              id="density"
-              type="number"
-              step="0.0001"
-              value={formData.density}
-              onChange={(e) =>
-                setFormData({ ...formData, density: e.target.value })
-              }
-              placeholder="Auto-calculated"
-              disabled
-              className="bg-muted"
-            />
-            <p className="text-sm text-muted-foreground">
-              Density is automatically calculated from gallons and lbs
-            </p>
-          </div>
-
-          <div className="flex justify-end gap-2 pt-4">
+          <SheetFooter className="flex-col gap-2 border-t border-border p-4 sm:flex-row sm:justify-end">
             <Button
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
               disabled={loading}
+              className="w-full sm:w-auto"
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={loading}>
+            <Button
+              type="submit"
+              disabled={loading}
+              className="w-full sm:w-auto"
+            >
               {loading ? 'Saving...' : transaction ? 'Update' : 'Create'}
             </Button>
-          </div>
+          </SheetFooter>
         </form>
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   )
 }

--- a/frontend/apps/web/components/fuel-farm/tank-form-dialog.tsx
+++ b/frontend/apps/web/components/fuel-farm/tank-form-dialog.tsx
@@ -1,13 +1,10 @@
 'use client'
 
-import type { TankWithLatestReading, TankInsert } from '@/repositories/tanks.repo'
+import type {
+  TankInsert,
+  TankWithLatestReading
+} from '@/repositories/tanks.repo'
 import { Button } from '@frontend/ui/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle
-} from '@frontend/ui/components/ui/dialog'
 import { Input } from '@frontend/ui/components/ui/input'
 import { Label } from '@frontend/ui/components/ui/label'
 import {
@@ -17,6 +14,14 @@ import {
   SelectTrigger,
   SelectValue
 } from '@frontend/ui/components/ui/select'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle
+} from '@frontend/ui/components/ui/sheet'
 import { useEffect, useState } from 'react'
 
 interface TankFormDialogProps {
@@ -84,85 +89,184 @@ export function TankFormDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>{tank ? 'Edit Tank' : 'Create Tank'}</DialogTitle>
-        </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="tank_id">Tank ID *</Label>
-              <Input id="tank_id" value={formData.tank_id as string}
-                onChange={(e) => setFormData({ ...formData, tank_id: e.target.value })}
-                required placeholder="e.g., TANK-1" disabled={!!tank} />
-              {tank && <p className="text-xs text-muted-foreground">Tank ID cannot be changed</p>}
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex w-full flex-col gap-0 p-0 sm:max-w-md"
+      >
+        <SheetHeader className="border-b border-border p-4">
+          <SheetTitle>{tank ? 'Edit Tank' : 'Create Tank'}</SheetTitle>
+          <SheetDescription>
+            {tank
+              ? 'Update the configuration for this fuel tank.'
+              : 'Add a new fuel tank to the farm.'}
+          </SheetDescription>
+        </SheetHeader>
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-1 flex-col overflow-hidden"
+        >
+          <div className="flex-1 space-y-4 overflow-y-auto p-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="tank_id">Tank ID *</Label>
+                <Input
+                  id="tank_id"
+                  value={formData.tank_id as string}
+                  onChange={(e) =>
+                    setFormData({ ...formData, tank_id: e.target.value })
+                  }
+                  required
+                  placeholder="e.g., TANK-1"
+                  disabled={!!tank}
+                />
+                {tank && (
+                  <p className="text-xs text-muted-foreground">
+                    Tank ID cannot be changed
+                  </p>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="tank_name">Tank Name *</Label>
+                <Input
+                  id="tank_name"
+                  value={formData.tank_name as string}
+                  onChange={(e) =>
+                    setFormData({ ...formData, tank_name: e.target.value })
+                  }
+                  required
+                  placeholder="e.g., Jet A Main"
+                />
+              </div>
             </div>
+
             <div className="space-y-2">
-              <Label htmlFor="tank_name">Tank Name *</Label>
-              <Input id="tank_name" value={formData.tank_name as string}
-                onChange={(e) => setFormData({ ...formData, tank_name: e.target.value })}
-                required placeholder="e.g., Jet A Main" />
+              <Label>Fuel Type *</Label>
+              <Select
+                value={formData.fuel_type as string}
+                onValueChange={(v) =>
+                  setFormData({
+                    ...formData,
+                    fuel_type: v as 'jet_a' | 'avgas'
+                  })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select fuel type" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="jet_a">Jet A</SelectItem>
+                  <SelectItem value="avgas">Avgas</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="capacity">Capacity (Gallons) *</Label>
+              <Input
+                id="capacity"
+                type="number"
+                step="0.01"
+                value={formData.capacity_gallons as string}
+                onChange={(e) =>
+                  setFormData({ ...formData, capacity_gallons: e.target.value })
+                }
+                required
+                placeholder="0.00"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Min Level (inches) *</Label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  value={formData.min_level_inches as string}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      min_level_inches: e.target.value
+                    })
+                  }
+                  required
+                  placeholder="0.00"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Max Level (inches) *</Label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  value={formData.max_level_inches as string}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      max_level_inches: e.target.value
+                    })
+                  }
+                  required
+                  placeholder="0.00"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Usable Min (inches) *</Label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  value={formData.usable_min_inches as string}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      usable_min_inches: e.target.value
+                    })
+                  }
+                  required
+                  placeholder="0.00"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Usable Max (inches) *</Label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  value={formData.usable_max_inches as string}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      usable_max_inches: e.target.value
+                    })
+                  }
+                  required
+                  placeholder="0.00"
+                />
+              </div>
             </div>
           </div>
 
-          <div className="space-y-2">
-            <Label>Fuel Type *</Label>
-            <Select value={formData.fuel_type as string}
-              onValueChange={(v) => setFormData({ ...formData, fuel_type: v as 'jet_a' | 'avgas' })}>
-              <SelectTrigger><SelectValue placeholder="Select fuel type" /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="jet_a">Jet A</SelectItem>
-                <SelectItem value="avgas">Avgas</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="capacity">Capacity (Gallons) *</Label>
-            <Input id="capacity" type="number" step="0.01" value={formData.capacity_gallons as string}
-              onChange={(e) => setFormData({ ...formData, capacity_gallons: e.target.value })}
-              required placeholder="0.00" />
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label>Min Level (inches) *</Label>
-              <Input type="number" step="0.01" value={formData.min_level_inches as string}
-                onChange={(e) => setFormData({ ...formData, min_level_inches: e.target.value })}
-                required placeholder="0.00" />
-            </div>
-            <div className="space-y-2">
-              <Label>Max Level (inches) *</Label>
-              <Input type="number" step="0.01" value={formData.max_level_inches as string}
-                onChange={(e) => setFormData({ ...formData, max_level_inches: e.target.value })}
-                required placeholder="0.00" />
-            </div>
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label>Usable Min (inches) *</Label>
-              <Input type="number" step="0.01" value={formData.usable_min_inches as string}
-                onChange={(e) => setFormData({ ...formData, usable_min_inches: e.target.value })}
-                required placeholder="0.00" />
-            </div>
-            <div className="space-y-2">
-              <Label>Usable Max (inches) *</Label>
-              <Input type="number" step="0.01" value={formData.usable_max_inches as string}
-                onChange={(e) => setFormData({ ...formData, usable_max_inches: e.target.value })}
-                required placeholder="0.00" />
-            </div>
-          </div>
-
-          <div className="flex justify-end gap-2 pt-4">
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>Cancel</Button>
-            <Button type="submit" disabled={loading}>
+          <SheetFooter className="flex-col gap-2 border-t border-border p-4 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={loading}
+              className="w-full sm:w-auto"
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={loading}
+              className="w-full sm:w-auto"
+            >
               {loading ? 'Saving...' : tank ? 'Update' : 'Create'}
             </Button>
-          </div>
+          </SheetFooter>
         </form>
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   )
 }


### PR DESCRIPTION
## Summary

The product owner picked the slideout (`Sheet`, `side="right"`) as the single house standard for all create/edit UI. This PR migrates the in-scope data-entry `Dialog` forms to that pattern and documents the convention.

UI-shell change only — form state, validation, and submit behavior are unchanged.

## Files migrated (this branch)

- `frontend/apps/web/components/fuel-farm/tank-form-dialog.tsx`
- `frontend/apps/web/components/fuel-dispatch/transaction-form-dialog.tsx`

## Migrated on its own branch (not merged here)

- `frontend/components/line-schedule/shift-form-dialog.tsx` on `worktree-truck-sheets` (that branch predates the frontend monorepo restructure, so the change lives there)

## Convention doc

- `docs/ui-conventions.md` — when to use `Sheet` vs `Dialog` vs `AlertDialog`, plus the standard slideout skeleton (width `sm:max-w-md`, bordered pinned header/footer, scrollable body, right-aligned Cancel + primary footer buttons, destructive action far-left)
- Linked from `docs/development.md` Coding Standards

## Intentionally NOT touched (in-flight rewrites / frozen)

- `invoicing/*`, `equipment/*` — concurrent rebuilds in progress
- `training/*`, `flight-operations/*` — competing implementations pending a decision
- `parking/*` — frozen/deferred (`parking/aircraft-sheet.tsx` was used as the style exemplar)
- user-management/users/roles — being built fresh separately
- `packages/ui/components/ui/command.tsx` — uses Dialog internally for the command palette, not a data-entry form
- `line-schedule/shift-popover.tsx` (truck-sheets branch) — read-only hour-detail viewer, stays a Dialog per the convention

## Verification

- `tsc --noEmit`: zero errors in migrated files (pre-existing errors in untouched `components/forms/*` remain)
- Biome check/format applied; remaining lint warnings on these files are pre-existing logic-level items (exhaustive-deps, isNaN) out of scope for a UI-shell change
