### PR TITLE
Add missing equipment table and seed ground support fleet

### DIFF
--- a/frontend/apps/web/app/equipment/page.tsx
+++ b/frontend/apps/web/app/equipment/page.tsx
@@ -5,10 +5,22 @@ import { useSession } from '@/hooks/use-session'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
-import { useEquipment } from '@/hooks/use-equipment'
-import type { EquipmentDomain } from '@/types/domain/equipment'
 import { EquipmentFormDialog } from '@/components/equipment/equipment-form-dialog'
+import { useEquipment } from '@/hooks/use-equipment'
+import {
+  EQUIPMENT_TYPES,
+  type EquipmentType,
+  getEquipmentTypeDefinition
+} from '@/lib/equipment-types'
+import type { EquipmentDomain } from '@/types/domain/equipment'
 import { Button } from '@frontend/ui/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@frontend/ui/components/ui/select'
 
 export default function EquipmentPage() {
   const { data: session, status } = useSession()
@@ -23,12 +35,20 @@ export default function EquipmentPage() {
     createEquipment,
     updateEquipment,
     deleteEquipment,
-    refetch,
+    refetch
   } = useEquipment()
 
   // modal states
   const [dialogOpen, setDialogOpen] = useState(false)
-  const [editingEquipment, setEditingEquipment] = useState<EquipmentDomain | null>(null)
+  const [editingEquipment, setEditingEquipment] =
+    useState<EquipmentDomain | null>(null)
+
+  // type filter
+  const [typeFilter, setTypeFilter] = useState<EquipmentType | 'all'>('all')
+  const filteredEquipment =
+    typeFilter === 'all'
+      ? equipment
+      : equipment.filter((e) => e.equipment_type === typeFilter)
 
   useEffect(() => {
     if (status === 'unauthenticated') {
@@ -56,7 +76,6 @@ export default function EquipmentPage() {
 
   return (
     <div className="space-y-6">
-
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
@@ -70,7 +89,7 @@ export default function EquipmentPage() {
         <Button
           className="bg-primary text-primary-foreground hover:bg-primary/90"
           onClick={() => {
-            setEditingEquipment(null)  // create mode
+            setEditingEquipment(null) // create mode
             setDialogOpen(true)
           }}
         >
@@ -108,44 +127,73 @@ export default function EquipmentPage() {
 
       {/* TABLE OR PLACEHOLDER */}
       <div className="rounded-lg bg-card shadow border border-border">
-        <div className="px-6 py-5 border-b border-border">
+        <div className="px-6 py-5 border-b border-border flex items-center justify-between gap-4">
           <h2 className="text-lg font-semibold text-foreground">
             Equipment Inventory
           </h2>
+
+          <Select
+            value={typeFilter}
+            onValueChange={(value) =>
+              setTypeFilter(value as EquipmentType | 'all')
+            }
+          >
+            <SelectTrigger className="w-48">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Types</SelectItem>
+              {EQUIPMENT_TYPES.map(({ value, label }) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
 
-        {equipment.length === 0 ? (
+        {filteredEquipment.length === 0 ? (
           <div className="p-8 text-center">
             <div className="text-muted-foreground">
-              No equipment found. Add equipment to get started.
+              {equipment.length === 0
+                ? 'No equipment found. Add equipment to get started.'
+                : 'No equipment matches this type.'}
             </div>
           </div>
         ) : (
           <div className="p-6">
             <ul className="space-y-2">
-              {equipment.map((item) => (
-                <li
-                  key={item.id}
-                  className="p-4 border rounded flex justify-between items-center bg-card"
-                >
-                  <div>
-                    <strong>{item.equipment_name}</strong>
-                    <div className="text-muted-foreground text-sm">
-                      {item.equipment_type} • {item.status}
-                    </div>
-                  </div>
-
-                  <Button
-                    variant="outline"
-                    onClick={() => {
-                      setEditingEquipment(item)
-                      setDialogOpen(true)
-                    }}
+              {filteredEquipment.map((item) => {
+                const { label, icon: Icon } = getEquipmentTypeDefinition(
+                  item.equipment_type
+                )
+                return (
+                  <li
+                    key={item.id}
+                    className="p-4 border rounded flex justify-between items-center bg-card"
                   >
-                    Edit
-                  </Button>
-                </li>
-              ))}
+                    <div className="flex items-center gap-3">
+                      <Icon className="size-5 text-muted-foreground shrink-0" />
+                      <div>
+                        <strong>{item.equipment_name}</strong>
+                        <div className="text-muted-foreground text-sm">
+                          {label} • {item.status}
+                        </div>
+                      </div>
+                    </div>
+
+                    <Button
+                      variant="outline"
+                      onClick={() => {
+                        setEditingEquipment(item)
+                        setDialogOpen(true)
+                      }}
+                    >
+                      Edit
+                    </Button>
+                  </li>
+                )
+              })}
             </ul>
           </div>
         )}
@@ -169,4 +217,3 @@ export default function EquipmentPage() {
     </div>
   )
 }
-

--- a/frontend/apps/web/components/equipment/equipment-form-dialog.tsx
+++ b/frontend/apps/web/components/equipment/equipment-form-dialog.tsx
@@ -1,12 +1,27 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@frontend/ui/components/ui/dialog'
+import { EQUIPMENT_TYPES } from '@/lib/equipment-types'
+import type { EquipmentInsert } from '@/repositories/equipment.repo'
+import type { EquipmentDomain } from '@/types/domain/equipment'
 import { Button } from '@frontend/ui/components/ui/button'
 import { Input } from '@frontend/ui/components/ui/input'
 import { Label } from '@frontend/ui/components/ui/label'
-import type { EquipmentInsert } from '@/repositories/equipment.repo'
-import type { EquipmentDomain } from '@/types/domain/equipment'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@frontend/ui/components/ui/select'
+import {
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle
+} from '@frontend/ui/components/ui/sheet'
+import { Textarea } from '@frontend/ui/components/ui/textarea'
+import { useEffect, useState } from 'react'
 
 interface EquipmentFormDialogProps {
   open: boolean
@@ -32,7 +47,12 @@ const emptyForm: EquipmentInsert = {
   next_maintenance_date: null
 }
 
-export function EquipmentFormDialog({ open, onOpenChange, equipment, onSubmit }: EquipmentFormDialogProps) {
+export function EquipmentFormDialog({
+  open,
+  onOpenChange,
+  equipment,
+  onSubmit
+}: EquipmentFormDialogProps) {
   const [form, setForm] = useState<EquipmentInsert>(emptyForm)
 
   useEffect(() => {
@@ -55,8 +75,11 @@ export function EquipmentFormDialog({ open, onOpenChange, equipment, onSubmit }:
     }
   }, [equipment, open])
 
-  const updateField = <K extends keyof EquipmentInsert>(key: K, value: EquipmentInsert[K]) => {
-    setForm(prev => ({ ...prev, [key]: value }))
+  const updateField = <K extends keyof EquipmentInsert>(
+    key: K,
+    value: EquipmentInsert[K]
+  ) => {
+    setForm((prev) => ({ ...prev, [key]: value }))
   }
 
   const handleSave = async () => {
@@ -65,96 +88,144 @@ export function EquipmentFormDialog({ open, onOpenChange, equipment, onSubmit }:
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-xl">
-        <DialogHeader>
-          <DialogTitle>{equipment ? 'Edit Equipment' : 'Add Equipment'}</DialogTitle>
-        </DialogHeader>
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="sm:max-w-xl overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>
+            {equipment ? 'Edit Equipment' : 'Add Equipment'}
+          </SheetTitle>
+        </SheetHeader>
 
-        <div className="space-y-4 mt-4">
+        <div className="space-y-4 px-4">
           <div>
             <Label>Equipment ID</Label>
-            <Input value={form.equipment_id as string}
+            <Input
+              value={form.equipment_id as string}
               onChange={(e) => updateField('equipment_id', e.target.value)}
-              disabled={!!equipment} />
+              disabled={!!equipment}
+            />
           </div>
 
           <div>
             <Label>Name</Label>
-            <Input value={form.equipment_name as string}
-              onChange={(e) => updateField('equipment_name', e.target.value)} />
+            <Input
+              value={form.equipment_name as string}
+              onChange={(e) => updateField('equipment_name', e.target.value)}
+            />
           </div>
 
           <div>
             <Label>Equipment Type</Label>
-            <select className="w-full border rounded p-2" value={form.equipment_type as string}
-              onChange={(e) => updateField('equipment_type', e.target.value as EquipmentType)}>
-              {['fuel_truck', 'tug', 'gpu', 'air_start', 'belt_loader', 'stairs', 'lavatory_service', 'water_service', 'other'].map((v) => (
-                <option key={v} value={v}>{v.replace(/_/g, ' ')}</option>
-              ))}
-            </select>
+            <Select
+              value={form.equipment_type as string}
+              onValueChange={(value) =>
+                updateField('equipment_type', value as EquipmentType)
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {EQUIPMENT_TYPES.map(({ value, label }) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
 
           <div className="grid grid-cols-2 gap-4">
             <div>
               <Label>Manufacturer</Label>
-              <Input value={form.manufacturer as string}
-                onChange={(e) => updateField('manufacturer', e.target.value)} />
+              <Input
+                value={form.manufacturer as string}
+                onChange={(e) => updateField('manufacturer', e.target.value)}
+              />
             </div>
             <div>
               <Label>Model</Label>
-              <Input value={form.model as string}
-                onChange={(e) => updateField('model', e.target.value)} />
+              <Input
+                value={form.model as string}
+                onChange={(e) => updateField('model', e.target.value)}
+              />
             </div>
           </div>
 
           <div>
             <Label>Serial Number</Label>
-            <Input value={form.serial_number as string}
-              onChange={(e) => updateField('serial_number', e.target.value)} />
+            <Input
+              value={form.serial_number as string}
+              onChange={(e) => updateField('serial_number', e.target.value)}
+            />
           </div>
 
           <div>
             <Label>Status</Label>
-            <select className="w-full border rounded p-2" value={form.status as string}
-              onChange={(e) => updateField('status', e.target.value as EquipmentStatus)}>
-              <option value="available">Available</option>
-              <option value="in_use">In Use</option>
-              <option value="maintenance">Maintenance</option>
-              <option value="out_of_service">Out of Service</option>
-            </select>
+            <Select
+              value={form.status as string}
+              onValueChange={(value) =>
+                updateField('status', value as EquipmentStatus)
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="available">Available</SelectItem>
+                <SelectItem value="in_use">In Use</SelectItem>
+                <SelectItem value="maintenance">Maintenance</SelectItem>
+                <SelectItem value="out_of_service">Out of Service</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
 
           <div>
             <Label>Location</Label>
-            <Input value={form.location as string}
-              onChange={(e) => updateField('location', e.target.value)} />
+            <Input
+              value={form.location as string}
+              onChange={(e) => updateField('location', e.target.value)}
+            />
           </div>
 
           <div>
             <Label>Notes</Label>
-            <textarea className="w-full border rounded p-2" value={form.notes as string}
-              onChange={(e) => updateField('notes', e.target.value)} />
+            <Textarea
+              value={form.notes as string}
+              onChange={(e) => updateField('notes', e.target.value)}
+            />
           </div>
 
           <div className="grid grid-cols-2 gap-4">
             <div>
               <Label>Last Maintenance</Label>
-              <Input type="date" value={(form.last_maintenance_date as string) ?? ''}
-                onChange={(e) => updateField('last_maintenance_date', e.target.value || null)} />
+              <Input
+                type="date"
+                value={(form.last_maintenance_date as string) ?? ''}
+                onChange={(e) =>
+                  updateField('last_maintenance_date', e.target.value || null)
+                }
+              />
             </div>
             <div>
               <Label>Next Maintenance</Label>
-              <Input type="date" value={(form.next_maintenance_date as string) ?? ''}
-                onChange={(e) => updateField('next_maintenance_date', e.target.value || null)} />
+              <Input
+                type="date"
+                value={(form.next_maintenance_date as string) ?? ''}
+                onChange={(e) =>
+                  updateField('next_maintenance_date', e.target.value || null)
+                }
+              />
             </div>
           </div>
+        </div>
 
-          <Button className="w-full mt-4" onClick={handleSave}>
+        <SheetFooter>
+          <Button className="w-full" onClick={handleSave}>
             {equipment ? 'Save Changes' : 'Add Equipment'}
           </Button>
-        </div>
-      </DialogContent>
-    </Dialog>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
   )
 }

--- a/frontend/apps/web/lib/equipment-types.ts
+++ b/frontend/apps/web/lib/equipment-types.ts
@@ -1,0 +1,50 @@
+import type { Database } from '@/types/database'
+import {
+  Car,
+  CircleDot,
+  CircleHelp,
+  Droplet,
+  Droplets,
+  Fuel,
+  Layers,
+  type LucideIcon,
+  Package,
+  Wind,
+  Wrench,
+  Zap
+} from 'lucide-react'
+
+export type EquipmentType =
+  Database['public']['Tables']['equipment']['Row']['equipment_type']
+
+export interface EquipmentTypeDefinition {
+  value: EquipmentType
+  label: string
+  icon: LucideIcon
+}
+
+export const EQUIPMENT_TYPES: EquipmentTypeDefinition[] = [
+  { value: 'fuel_truck', label: 'Fuel Truck', icon: Fuel },
+  { value: 'tug', label: 'Tug', icon: Wrench },
+  { value: 'gpu', label: 'Ground Power Unit', icon: Zap },
+  { value: 'air_start', label: 'Air Start Unit', icon: Wind },
+  { value: 'belt_loader', label: 'Belt Loader', icon: Package },
+  { value: 'stairs', label: 'Passenger Stairs', icon: Layers },
+  { value: 'lavatory_service', label: 'Lavatory Service', icon: Droplet },
+  { value: 'water_service', label: 'Water Service', icon: Droplets },
+  { value: 'golf_cart', label: 'Golf Cart', icon: CircleDot },
+  { value: 'staff_vehicle', label: 'Staff Vehicle', icon: Car },
+  { value: 'other', label: 'Other', icon: CircleHelp }
+]
+
+const EQUIPMENT_TYPE_MAP = new Map(
+  EQUIPMENT_TYPES.map((def) => [def.value, def])
+)
+
+export function getEquipmentTypeDefinition(
+  type: EquipmentType
+): EquipmentTypeDefinition {
+  return (
+    EQUIPMENT_TYPE_MAP.get(type) ?? EQUIPMENT_TYPES[EQUIPMENT_TYPES.length - 1]
+  )
+}

--- a/frontend/apps/web/types/database.ts
+++ b/frontend/apps/web/types/database.ts
@@ -421,7 +421,7 @@ export type Database = {
           id: number
           equipment_id: string
           equipment_name: string
-          equipment_type: 'fuel_truck' | 'tug' | 'gpu' | 'air_start' | 'belt_loader' | 'stairs' | 'lavatory_service' | 'water_service' | 'other'
+          equipment_type: 'fuel_truck' | 'tug' | 'gpu' | 'air_start' | 'belt_loader' | 'stairs' | 'lavatory_service' | 'water_service' | 'golf_cart' | 'staff_vehicle' | 'other'
           manufacturer: string
           model: string
           serial_number: string
@@ -437,7 +437,7 @@ export type Database = {
           id?: number
           equipment_id: string
           equipment_name: string
-          equipment_type: 'fuel_truck' | 'tug' | 'gpu' | 'air_start' | 'belt_loader' | 'stairs' | 'lavatory_service' | 'water_service' | 'other'
+          equipment_type: 'fuel_truck' | 'tug' | 'gpu' | 'air_start' | 'belt_loader' | 'stairs' | 'lavatory_service' | 'water_service' | 'golf_cart' | 'staff_vehicle' | 'other'
           manufacturer?: string
           model?: string
           serial_number?: string

--- a/frontend/scripts/equipment-schema.sql
+++ b/frontend/scripts/equipment-schema.sql
@@ -1,0 +1,88 @@
+-- Equipment Registry
+-- Run this in the Supabase SQL Editor (supabase.com/dashboard -> SQL Editor)
+-- or via psql against the pooler connection in frontend/.env.local.
+--
+-- This table is Supabase-native (not Django-managed) — the app was decoupled
+-- from Django to talk to Supabase directly. Column shapes mirror the retired
+-- Django model (backend/api/models.py, class Equipment) so existing
+-- expectations (id BIGSERIAL PK, equipment_id TEXT UNIQUE, ...) still hold.
+--
+-- equipment_type started as: fuel_truck, tug, gpu, air_start, belt_loader,
+-- stairs, lavatory_service, water_service, other. Two types were added here
+-- to cover the fleet's staff/ops vehicles and light transport:
+--   golf_cart      - ramp golf carts
+--   staff_vehicle  - cars/SUVs used for staff & ops (e.g. sedans, Suburbans)
+
+-- ============================================================
+-- 1. Table
+-- ============================================================
+CREATE TABLE IF NOT EXISTS equipment (
+  id                     BIGSERIAL PRIMARY KEY,
+  equipment_id           TEXT NOT NULL UNIQUE,
+  equipment_name         TEXT NOT NULL,
+  equipment_type         TEXT NOT NULL CHECK (equipment_type IN (
+                             'fuel_truck', 'tug', 'gpu', 'air_start', 'belt_loader',
+                             'stairs', 'lavatory_service', 'water_service',
+                             'golf_cart', 'staff_vehicle', 'other'
+                           )),
+  manufacturer           TEXT NOT NULL DEFAULT '',
+  model                  TEXT NOT NULL DEFAULT '',
+  serial_number          TEXT NOT NULL DEFAULT '',
+  status                 TEXT NOT NULL DEFAULT 'available' CHECK (status IN (
+                             'available', 'in_use', 'maintenance', 'out_of_service'
+                           )),
+  location               TEXT NOT NULL DEFAULT '',
+  notes                  TEXT NOT NULL DEFAULT '',
+  last_maintenance_date  DATE,
+  next_maintenance_date  DATE,
+  created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  modified_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_equipment_type   ON equipment(equipment_type);
+CREATE INDEX IF NOT EXISTS idx_equipment_status ON equipment(status);
+
+-- ============================================================
+-- 2. Seed the fleet
+--    Fuel truck IDs match frontend/scripts/truck-sheets-schema.sql's own
+--    seed exactly (ON CONFLICT DO NOTHING keeps both scripts idempotent
+--    and safe to run in either order).
+-- ============================================================
+INSERT INTO equipment
+  (equipment_id, equipment_name, equipment_type, manufacturer, model,
+   serial_number, status, location, notes, created_at, modified_at)
+VALUES
+  -- Aviation fuel trucks (Jet A / Avgas) — feed the truck-sheets workflow
+  ('5282', 'Fuel Truck 5282 (Jet A, 5,000 gal)', 'fuel_truck', '', '', '', 'available', '', 'Fuel: Jet A. Capacity: 5000 gal. Front + rear meter registers.', NOW(), NOW()),
+  ('8178', 'Fuel Truck 8178 (Jet A, 3,000 gal)', 'fuel_truck', '', '', '', 'available', '', 'Fuel: Jet A. Capacity: 3000 gal. Front + rear meter registers.', NOW(), NOW()),
+  ('8370', 'Fuel Truck 8370 (Jet A, 3,000 gal)', 'fuel_truck', '', '', '', 'available', '', 'Fuel: Jet A. Capacity: 3000 gal. Front + rear meter registers.', NOW(), NOW()),
+  ('8628', 'Fuel Truck 8628 (Jet A, 3,000 gal)', 'fuel_truck', '', '', '', 'available', '', 'Fuel: Jet A. Capacity: 3000 gal. Front + rear meter registers.', NOW(), NOW()),
+  ('5183', 'Fuel Truck 5183 (Avgas, 750 gal)',   'fuel_truck', '', '', '', 'available', '', 'Fuel: Avgas 100LL. Capacity: 750 gal. Front meter only.', NOW(), NOW()),
+  ('8338', 'Fuel Truck 8338 (Avgas, 2,000 gal)', 'fuel_truck', '', '', '', 'available', '', 'Fuel: Avgas 100LL. Capacity: 2000 gal. Front meter only.', NOW(), NOW()),
+
+  -- Ground-service fuel truck (diesel/gasoline) — NOT an aircraft fuel truck.
+  -- Deliberately excluded from the truck-sheets Jet A/Avgas workflow, whose
+  -- truck_sheets table CHECKs fuel_type IN ('jet_a', 'avgas').
+  ('3183', 'Fuel Truck 3183 (Diesel/Gas, Ground Service)', 'fuel_truck', '', '', '', 'available', '', 'Diesel/gasoline — ground equipment servicing, not aircraft fueling. Not part of the Jet A/Avgas truck-sheets workflow.', NOW(), NOW()),
+
+  -- Golf cart
+  ('GC-1', 'Golf Cart 1', 'golf_cart', '', '', '', 'available', '', '', NOW(), NOW()),
+
+  -- Tugs
+  ('TUG-1', 'Tug 1', 'tug', '', '', '', 'available', '', '', NOW(), NOW()),
+  ('TUG-2', 'Tug 2', 'tug', '', '', '', 'available', '', '', NOW(), NOW()),
+  ('TUG-LEKTRO', 'Lektro Tug', 'tug', 'Lektro', '', '', 'available', '', 'Electric aircraft tow tractor.', NOW(), NOW()),
+
+  -- Staff/ops vehicles
+  ('VEH-MALIBU', 'Malibu', 'staff_vehicle', 'Chevrolet', 'Malibu', '', 'available', '', 'White staff/ops sedan.', NOW(), NOW()),
+  ('VEH-SUBURBAN', 'Suburban', 'staff_vehicle', 'Chevrolet', 'Suburban', '', 'available', '', 'Purple staff/ops SUV.', NOW(), NOW())
+ON CONFLICT (equipment_id) DO NOTHING;
+
+-- ============================================================
+-- 3. RLS (matches house style: authenticated users manage all)
+-- ============================================================
+ALTER TABLE equipment ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Authenticated users can manage equipment"
+  ON equipment FOR ALL
+  USING (auth.role() = 'authenticated');


### PR DESCRIPTION
## Summary

The frontend equipment module already queried a Supabase `equipment` table that never existed in any schema — confirmed via direct `information_schema.tables` inspection. This adds it and backfills the fleet.

- `frontend/scripts/equipment-schema.sql` (new): `CREATE TABLE IF NOT EXISTS equipment` mirroring the retired Django `Equipment` model (`backend/api/models.py:633`), with `equipment_type`/`status` CHECK constraints, indexes, and RLS matching house style.
- Idempotent seed (13 rows): the 6 existing fuel trucks (matching `truck-sheets-schema.sql` exactly so there's no collision once that branch merges), new ground-service truck `3183`, golf cart `GC-1`, tugs `TUG-1`/`TUG-2`/`TUG-LEKTRO`, staff vehicles `VEH-MALIBU`/`VEH-SUBURBAN`.
- Extended `equipment_type` with `golf_cart` and `staff_vehicle` to cover the new categories; updated generated DB types.
- Migrated the equipment add/edit form from `Dialog` to `Sheet` per the house-wide slideout convention.
- Equipment page now shows a type icon/label per row plus a type filter.

## Verification

- Ran the migration against the live Supabase database and confirmed via `SELECT`: table + indexes + constraints + RLS + policy + all 13 seed rows landed.
- `tsc --noEmit`: 21 pre-existing errors, identical count before/after (verified via git stash A/B comparison) — none in equipment files, nothing introduced.
- `biome check`: clean except one pre-existing, unmodified warning.

## Note on branch base

This worktree was created from `origin/master` (monorepo `frontend/apps/web` + `packages/` layout), which differs from the flat `frontend/` layout on `nimbalyst-qa`/`truck-sheets`. The equipment module is functionally identical either way (same `.from('equipment')` calls), so this targets `master` directly against its actual file paths.