### PR TITLE
refactor(ui): standardize create/edit forms on Sheet slideout

### DIFF
--- a/frontend/components/fuel-dispatch/transaction-form-dialog.tsx
+++ b/frontend/components/fuel-dispatch/transaction-form-dialog.tsx
@@ -6,12 +6,6 @@ import type {
   ProgressEnum
 } from '@/types/api'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle
-} from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
@@ -21,6 +15,14 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle
+} from '@/components/ui/sheet'
 import { useEffect, useState } from 'react'
 import { useFlights } from '../../hooks/use-flights'
 
@@ -98,118 +100,140 @@ export function TransactionFormDialog({
   }, [formData.quantity_gallons, formData.quantity_lbs])
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex w-full flex-col gap-0 p-0 sm:max-w-md"
+      >
+        <SheetHeader className="border-b border-border p-4">
+          <SheetTitle>
             {transaction ? 'Edit Transaction' : 'Create Transaction'}
-          </DialogTitle>
-        </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="ticket_number">Ticket Number *</Label>
-            <Input
-              id="ticket_number"
-              value={formData.ticket_number}
-              onChange={(e) =>
-                setFormData({ ...formData, ticket_number: e.target.value })
-              }
-              required
-              placeholder="Enter ticket number"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="flight">Flight (Optional)</Label>
-            <Select
-              value={formData.flight?.toString() || 'none'}
-              onValueChange={(value) =>
-                setFormData({
-                  ...formData,
-                  flight: value === 'none' ? null : Number.parseInt(value)
-                })
-              }
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Select a flight" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">No flight assigned</SelectItem>
-                {flights.map((flight) => (
-                  <SelectItem key={flight.id} value={flight.id}>
-                    {flight.callSign ?? flight.tailNumber} - {flight.aircraftType}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
+          </SheetTitle>
+          <SheetDescription>
+            {transaction
+              ? 'Update the details for this fuel transaction.'
+              : 'Record a new fuel transaction.'}
+          </SheetDescription>
+        </SheetHeader>
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-1 flex-col overflow-hidden"
+        >
+          <div className="flex-1 space-y-4 overflow-y-auto p-4">
             <div className="space-y-2">
-              <Label htmlFor="quantity_gallons">Quantity (Gallons) *</Label>
+              <Label htmlFor="ticket_number">Ticket Number *</Label>
               <Input
-                id="quantity_gallons"
-                type="number"
-                step="0.01"
-                value={formData.quantity_gallons}
+                id="ticket_number"
+                value={formData.ticket_number}
                 onChange={(e) =>
-                  setFormData({ ...formData, quantity_gallons: e.target.value })
+                  setFormData({ ...formData, ticket_number: e.target.value })
                 }
                 required
-                placeholder="0.00"
+                placeholder="Enter ticket number"
               />
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="quantity_lbs">Quantity (Lbs) *</Label>
-              <Input
-                id="quantity_lbs"
-                type="number"
-                step="0.01"
-                value={formData.quantity_lbs}
-                onChange={(e) =>
-                  setFormData({ ...formData, quantity_lbs: e.target.value })
+              <Label htmlFor="flight">Flight (Optional)</Label>
+              <Select
+                value={formData.flight?.toString() || 'none'}
+                onValueChange={(value) =>
+                  setFormData({
+                    ...formData,
+                    flight: value === 'none' ? null : Number.parseInt(value)
+                  })
                 }
-                required
-                placeholder="0.00"
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a flight" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">No flight assigned</SelectItem>
+                  {flights.map((flight) => (
+                    <SelectItem key={flight.id} value={flight.id}>
+                      {flight.callSign ?? flight.tailNumber} -{' '}
+                      {flight.aircraftType}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="quantity_gallons">Quantity (Gallons) *</Label>
+                <Input
+                  id="quantity_gallons"
+                  type="number"
+                  step="0.01"
+                  value={formData.quantity_gallons}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      quantity_gallons: e.target.value
+                    })
+                  }
+                  required
+                  placeholder="0.00"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="quantity_lbs">Quantity (Lbs) *</Label>
+                <Input
+                  id="quantity_lbs"
+                  type="number"
+                  step="0.01"
+                  value={formData.quantity_lbs}
+                  onChange={(e) =>
+                    setFormData({ ...formData, quantity_lbs: e.target.value })
+                  }
+                  required
+                  placeholder="0.00"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="density">Density (lbs/gal)</Label>
+              <Input
+                id="density"
+                type="number"
+                step="0.0001"
+                value={formData.density}
+                onChange={(e) =>
+                  setFormData({ ...formData, density: e.target.value })
+                }
+                placeholder="Auto-calculated"
+                disabled
+                className="bg-muted"
               />
+              <p className="text-sm text-muted-foreground">
+                Density is automatically calculated from gallons and lbs
+              </p>
             </div>
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="density">Density (lbs/gal)</Label>
-            <Input
-              id="density"
-              type="number"
-              step="0.0001"
-              value={formData.density}
-              onChange={(e) =>
-                setFormData({ ...formData, density: e.target.value })
-              }
-              placeholder="Auto-calculated"
-              disabled
-              className="bg-muted"
-            />
-            <p className="text-sm text-muted-foreground">
-              Density is automatically calculated from gallons and lbs
-            </p>
-          </div>
-
-          <div className="flex justify-end gap-2 pt-4">
+          <SheetFooter className="flex-col gap-2 border-t border-border p-4 sm:flex-row sm:justify-end">
             <Button
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
               disabled={loading}
+              className="w-full sm:w-auto"
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={loading}>
+            <Button
+              type="submit"
+              disabled={loading}
+              className="w-full sm:w-auto"
+            >
               {loading ? 'Saving...' : transaction ? 'Update' : 'Create'}
             </Button>
-          </div>
+          </SheetFooter>
         </form>
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   )
 }

--- a/frontend/components/fuel-farm/tank-form-dialog.tsx
+++ b/frontend/components/fuel-farm/tank-form-dialog.tsx
@@ -1,13 +1,10 @@
 'use client'
 
-import type { TankWithLatestReading, TankInsert } from '@/repositories/tanks.repo'
+import type {
+  TankInsert,
+  TankWithLatestReading
+} from '@/repositories/tanks.repo'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle
-} from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
@@ -17,6 +14,14 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle
+} from '@/components/ui/sheet'
 import { useEffect, useState } from 'react'
 
 interface TankFormDialogProps {
@@ -84,85 +89,184 @@ export function TankFormDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>{tank ? 'Edit Tank' : 'Create Tank'}</DialogTitle>
-        </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="tank_id">Tank ID *</Label>
-              <Input id="tank_id" value={formData.tank_id as string}
-                onChange={(e) => setFormData({ ...formData, tank_id: e.target.value })}
-                required placeholder="e.g., TANK-1" disabled={!!tank} />
-              {tank && <p className="text-xs text-muted-foreground">Tank ID cannot be changed</p>}
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex w-full flex-col gap-0 p-0 sm:max-w-md"
+      >
+        <SheetHeader className="border-b border-border p-4">
+          <SheetTitle>{tank ? 'Edit Tank' : 'Create Tank'}</SheetTitle>
+          <SheetDescription>
+            {tank
+              ? 'Update the configuration for this fuel tank.'
+              : 'Add a new fuel tank to the farm.'}
+          </SheetDescription>
+        </SheetHeader>
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-1 flex-col overflow-hidden"
+        >
+          <div className="flex-1 space-y-4 overflow-y-auto p-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="tank_id">Tank ID *</Label>
+                <Input
+                  id="tank_id"
+                  value={formData.tank_id as string}
+                  onChange={(e) =>
+                    setFormData({ ...formData, tank_id: e.target.value })
+                  }
+                  required
+                  placeholder="e.g., TANK-1"
+                  disabled={!!tank}
+                />
+                {tank && (
+                  <p className="text-xs text-muted-foreground">
+                    Tank ID cannot be changed
+                  </p>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="tank_name">Tank Name *</Label>
+                <Input
+                  id="tank_name"
+                  value={formData.tank_name as string}
+                  onChange={(e) =>
+                    setFormData({ ...formData, tank_name: e.target.value })
+                  }
+                  required
+                  placeholder="e.g., Jet A Main"
+                />
+              </div>
             </div>
+
             <div className="space-y-2">
-              <Label htmlFor="tank_name">Tank Name *</Label>
-              <Input id="tank_name" value={formData.tank_name as string}
-                onChange={(e) => setFormData({ ...formData, tank_name: e.target.value })}
-                required placeholder="e.g., Jet A Main" />
+              <Label>Fuel Type *</Label>
+              <Select
+                value={formData.fuel_type as string}
+                onValueChange={(v) =>
+                  setFormData({
+                    ...formData,
+                    fuel_type: v as 'jet_a' | 'avgas'
+                  })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select fuel type" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="jet_a">Jet A</SelectItem>
+                  <SelectItem value="avgas">Avgas</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="capacity">Capacity (Gallons) *</Label>
+              <Input
+                id="capacity"
+                type="number"
+                step="0.01"
+                value={formData.capacity_gallons as string}
+                onChange={(e) =>
+                  setFormData({ ...formData, capacity_gallons: e.target.value })
+                }
+                required
+                placeholder="0.00"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Min Level (inches) *</Label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  value={formData.min_level_inches as string}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      min_level_inches: e.target.value
+                    })
+                  }
+                  required
+                  placeholder="0.00"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Max Level (inches) *</Label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  value={formData.max_level_inches as string}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      max_level_inches: e.target.value
+                    })
+                  }
+                  required
+                  placeholder="0.00"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Usable Min (inches) *</Label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  value={formData.usable_min_inches as string}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      usable_min_inches: e.target.value
+                    })
+                  }
+                  required
+                  placeholder="0.00"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Usable Max (inches) *</Label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  value={formData.usable_max_inches as string}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      usable_max_inches: e.target.value
+                    })
+                  }
+                  required
+                  placeholder="0.00"
+                />
+              </div>
             </div>
           </div>
 
-          <div className="space-y-2">
-            <Label>Fuel Type *</Label>
-            <Select value={formData.fuel_type as string}
-              onValueChange={(v) => setFormData({ ...formData, fuel_type: v as 'jet_a' | 'avgas' })}>
-              <SelectTrigger><SelectValue placeholder="Select fuel type" /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="jet_a">Jet A</SelectItem>
-                <SelectItem value="avgas">Avgas</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="capacity">Capacity (Gallons) *</Label>
-            <Input id="capacity" type="number" step="0.01" value={formData.capacity_gallons as string}
-              onChange={(e) => setFormData({ ...formData, capacity_gallons: e.target.value })}
-              required placeholder="0.00" />
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label>Min Level (inches) *</Label>
-              <Input type="number" step="0.01" value={formData.min_level_inches as string}
-                onChange={(e) => setFormData({ ...formData, min_level_inches: e.target.value })}
-                required placeholder="0.00" />
-            </div>
-            <div className="space-y-2">
-              <Label>Max Level (inches) *</Label>
-              <Input type="number" step="0.01" value={formData.max_level_inches as string}
-                onChange={(e) => setFormData({ ...formData, max_level_inches: e.target.value })}
-                required placeholder="0.00" />
-            </div>
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label>Usable Min (inches) *</Label>
-              <Input type="number" step="0.01" value={formData.usable_min_inches as string}
-                onChange={(e) => setFormData({ ...formData, usable_min_inches: e.target.value })}
-                required placeholder="0.00" />
-            </div>
-            <div className="space-y-2">
-              <Label>Usable Max (inches) *</Label>
-              <Input type="number" step="0.01" value={formData.usable_max_inches as string}
-                onChange={(e) => setFormData({ ...formData, usable_max_inches: e.target.value })}
-                required placeholder="0.00" />
-            </div>
-          </div>
-
-          <div className="flex justify-end gap-2 pt-4">
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>Cancel</Button>
-            <Button type="submit" disabled={loading}>
+          <SheetFooter className="flex-col gap-2 border-t border-border p-4 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={loading}
+              className="w-full sm:w-auto"
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={loading}
+              className="w-full sm:w-auto"
+            >
               {loading ? 'Saving...' : tank ? 'Update' : 'Create'}
             </Button>
-          </div>
+          </SheetFooter>
         </form>
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   )
 }


### PR DESCRIPTION
## Summary

The product owner picked the slideout (`Sheet`, `side="right"`) as the single house standard for all create/edit UI. This migrates the in-scope data-entry `Dialog` forms to that pattern.

UI-shell change only — form state, validation, and submit behavior are unchanged.

## Files migrated

- `frontend/components/fuel-farm/tank-form-dialog.tsx`
- `frontend/components/fuel-dispatch/transaction-form-dialog.tsx`

## Note

This supersedes #12, which was accidentally built against a stale pre-collapse monorepo branch layout (`frontend/apps/web/...`, `@frontend/ui/*` aliases) that no longer matches `master`. Same logic, ported onto the current flat `frontend/` structure with corrected import aliases. Closing #12 in favor of this one.

## Verification

- `tsc --noEmit`: zero errors