### PR TITLE
feat(equipment): golf cart/staff vehicle types, Sheet slideout form

### DIFF
--- a/frontend/app/equipment/page.tsx
+++ b/frontend/app/equipment/page.tsx
@@ -7,9 +7,16 @@ import { useEffect, useState } from 'react'
 import { useEquipment } from '@/hooks/use-equipment'
 import { useEquipmentRealtime } from '@/hooks/use-equipment-realtime'
 import { EquipmentFormDialog } from '@/components/equipment/equipment-form-dialog'
-import { EquipmentStatusCard } from '@/components/equipment/equipment-status-card'
+import { EquipmentStatusCard, EQUIPMENT_TYPES, formatTypeLabel } from '@/components/equipment/equipment-status-card'
 import type { EquipmentStatus } from '@/components/equipment/status-badge'
 import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
 import type { EquipmentDomain } from '@/types/domain/equipment'
 import type { EquipmentInsert } from '@/repositories/equipment.repo'
 
@@ -22,6 +29,7 @@ export default function EquipmentPage() {
 
   const [dialogOpen, setDialogOpen] = useState(false)
   const [editingEquipment, setEditingEquipment] = useState<EquipmentDomain | null>(null)
+  const [typeFilter, setTypeFilter] = useState<string>('all')
 
   useEffect(() => {
     if (status === 'unauthenticated') router.push('/login')
@@ -67,6 +75,9 @@ export default function EquipmentPage() {
     e => e.maintenanceStatus === 'due_soon' || e.maintenanceStatus === 'overdue'
   ).length
 
+  const filteredEquipment =
+    typeFilter === 'all' ? equipment : equipment.filter(e => e.equipment_type === typeFilter)
+
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -77,11 +88,26 @@ export default function EquipmentPage() {
             Live status board — updates in real time
           </p>
         </div>
-        <Button
-          onClick={() => { setEditingEquipment(null); setDialogOpen(true) }}
-        >
-          Add Equipment
-        </Button>
+        <div className="flex items-center gap-3">
+          <Select value={typeFilter} onValueChange={setTypeFilter}>
+            <SelectTrigger className="w-44">
+              <SelectValue placeholder="All Types" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Types</SelectItem>
+              {EQUIPMENT_TYPES.map(type => (
+                <SelectItem key={type} value={type}>
+                  {formatTypeLabel(type)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            onClick={() => { setEditingEquipment(null); setDialogOpen(true) }}
+          >
+            Add Equipment
+          </Button>
+        </div>
       </div>
 
       {/* Summary stats */}
@@ -123,9 +149,13 @@ export default function EquipmentPage() {
         <div className="rounded-lg bg-card border border-border p-12 text-center text-muted-foreground">
           No equipment found. Add equipment to get started.
         </div>
+      ) : filteredEquipment.length === 0 ? (
+        <div className="rounded-lg bg-card border border-border p-12 text-center text-muted-foreground">
+          No equipment matches this type.
+        </div>
       ) : (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {equipment.map(item => (
+          {filteredEquipment.map(item => (
             <EquipmentStatusCard
               key={item.id}
               equipment={item}

--- a/frontend/components/equipment/equipment-form-dialog.tsx
+++ b/frontend/components/equipment/equipment-form-dialog.tsx
@@ -1,10 +1,26 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle
+} from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { EQUIPMENT_TYPES, formatTypeLabel } from '@/components/equipment/equipment-status-card'
 import type { EquipmentInsert } from '@/repositories/equipment.repo'
 import type { EquipmentDomain } from '@/types/domain/equipment'
 
@@ -34,6 +50,7 @@ const emptyForm: EquipmentInsert = {
 
 export function EquipmentFormDialog({ open, onOpenChange, equipment, onSubmit }: EquipmentFormDialogProps) {
   const [form, setForm] = useState<EquipmentInsert>(emptyForm)
+  const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     if (equipment) {
@@ -59,102 +76,171 @@ export function EquipmentFormDialog({ open, onOpenChange, equipment, onSubmit }:
     setForm(prev => ({ ...prev, [key]: value }))
   }
 
-  const handleSave = async () => {
-    await onSubmit(form)
-    onOpenChange(false)
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    try {
+      await onSubmit(form)
+      onOpenChange(false)
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-xl">
-        <DialogHeader>
-          <DialogTitle>{equipment ? 'Edit Equipment' : 'Add Equipment'}</DialogTitle>
-        </DialogHeader>
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="flex w-full flex-col gap-0 p-0 sm:max-w-md">
+        <SheetHeader className="border-b border-border p-4">
+          <SheetTitle>{equipment ? 'Edit Equipment' : 'Add Equipment'}</SheetTitle>
+          <SheetDescription>
+            {equipment
+              ? 'Update the details for this piece of equipment.'
+              : 'Add a new piece of ground-support equipment.'}
+          </SheetDescription>
+        </SheetHeader>
 
-        <div className="space-y-4 mt-4">
-          <div>
-            <Label>Equipment ID</Label>
-            <Input value={form.equipment_id as string}
-              onChange={(e) => updateField('equipment_id', e.target.value)}
-              disabled={!!equipment} />
-          </div>
-
-          <div>
-            <Label>Name</Label>
-            <Input value={form.equipment_name as string}
-              onChange={(e) => updateField('equipment_name', e.target.value)} />
-          </div>
-
-          <div>
-            <Label>Equipment Type</Label>
-            <select className="w-full border rounded p-2" value={form.equipment_type as string}
-              onChange={(e) => updateField('equipment_type', e.target.value as EquipmentType)}>
-              {['fuel_truck', 'tug', 'gpu', 'air_start', 'belt_loader', 'stairs', 'lavatory_service', 'water_service', 'other'].map((v) => (
-                <option key={v} value={v}>{v.replace(/_/g, ' ')}</option>
-              ))}
-            </select>
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
+        <form onSubmit={handleSubmit} className="flex flex-1 flex-col overflow-hidden">
+          <div className="flex-1 space-y-4 overflow-y-auto p-4">
             <div>
-              <Label>Manufacturer</Label>
-              <Input value={form.manufacturer as string}
-                onChange={(e) => updateField('manufacturer', e.target.value)} />
+              <Label htmlFor="equipment_id">Equipment ID</Label>
+              <Input
+                id="equipment_id"
+                value={form.equipment_id as string}
+                onChange={(e) => updateField('equipment_id', e.target.value)}
+                disabled={!!equipment}
+              />
             </div>
+
             <div>
-              <Label>Model</Label>
-              <Input value={form.model as string}
-                onChange={(e) => updateField('model', e.target.value)} />
+              <Label htmlFor="equipment_name">Name</Label>
+              <Input
+                id="equipment_name"
+                value={form.equipment_name as string}
+                onChange={(e) => updateField('equipment_name', e.target.value)}
+              />
             </div>
-          </div>
 
-          <div>
-            <Label>Serial Number</Label>
-            <Input value={form.serial_number as string}
-              onChange={(e) => updateField('serial_number', e.target.value)} />
-          </div>
-
-          <div>
-            <Label>Status</Label>
-            <select className="w-full border rounded p-2" value={form.status as string}
-              onChange={(e) => updateField('status', e.target.value as EquipmentStatus)}>
-              <option value="available">Available</option>
-              <option value="in_use">In Use</option>
-              <option value="maintenance">Maintenance</option>
-              <option value="out_of_service">Out of Service</option>
-            </select>
-          </div>
-
-          <div>
-            <Label>Location</Label>
-            <Input value={form.location as string}
-              onChange={(e) => updateField('location', e.target.value)} />
-          </div>
-
-          <div>
-            <Label>Notes</Label>
-            <textarea className="w-full border rounded p-2" value={form.notes as string}
-              onChange={(e) => updateField('notes', e.target.value)} />
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
             <div>
-              <Label>Last Maintenance</Label>
-              <Input type="date" value={(form.last_maintenance_date as string) ?? ''}
-                onChange={(e) => updateField('last_maintenance_date', e.target.value || null)} />
+              <Label>Equipment Type</Label>
+              <Select
+                value={form.equipment_type as string}
+                onValueChange={(value) => updateField('equipment_type', value as EquipmentType)}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {EQUIPMENT_TYPES.map((type) => (
+                    <SelectItem key={type} value={type}>
+                      {formatTypeLabel(type)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="manufacturer">Manufacturer</Label>
+                <Input
+                  id="manufacturer"
+                  value={form.manufacturer as string}
+                  onChange={(e) => updateField('manufacturer', e.target.value)}
+                />
+              </div>
+              <div>
+                <Label htmlFor="model">Model</Label>
+                <Input
+                  id="model"
+                  value={form.model as string}
+                  onChange={(e) => updateField('model', e.target.value)}
+                />
+              </div>
+            </div>
+
             <div>
-              <Label>Next Maintenance</Label>
-              <Input type="date" value={(form.next_maintenance_date as string) ?? ''}
-                onChange={(e) => updateField('next_maintenance_date', e.target.value || null)} />
+              <Label htmlFor="serial_number">Serial Number</Label>
+              <Input
+                id="serial_number"
+                value={form.serial_number as string}
+                onChange={(e) => updateField('serial_number', e.target.value)}
+              />
+            </div>
+
+            <div>
+              <Label>Status</Label>
+              <Select
+                value={form.status as string}
+                onValueChange={(value) => updateField('status', value as EquipmentStatus)}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="available">Available</SelectItem>
+                  <SelectItem value="in_use">In Use</SelectItem>
+                  <SelectItem value="maintenance">Maintenance</SelectItem>
+                  <SelectItem value="out_of_service">Out of Service</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div>
+              <Label htmlFor="location">Location</Label>
+              <Input
+                id="location"
+                value={form.location as string}
+                onChange={(e) => updateField('location', e.target.value)}
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="notes">Notes</Label>
+              <Textarea
+                id="notes"
+                value={form.notes as string}
+                onChange={(e) => updateField('notes', e.target.value)}
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="last_maintenance_date">Last Maintenance</Label>
+                <Input
+                  id="last_maintenance_date"
+                  type="date"
+                  value={(form.last_maintenance_date as string) ?? ''}
+                  onChange={(e) => updateField('last_maintenance_date', e.target.value || null)}
+                />
+              </div>
+              <div>
+                <Label htmlFor="next_maintenance_date">Next Maintenance</Label>
+                <Input
+                  id="next_maintenance_date"
+                  type="date"
+                  value={(form.next_maintenance_date as string) ?? ''}
+                  onChange={(e) => updateField('next_maintenance_date', e.target.value || null)}
+                />
+              </div>
             </div>
           </div>
 
-          <Button className="w-full mt-4" onClick={handleSave}>
-            {equipment ? 'Save Changes' : 'Add Equipment'}
-          </Button>
-        </div>
-      </DialogContent>
-    </Dialog>
+          <SheetFooter className="flex-col gap-2 border-t border-border p-4 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={loading}
+              className="w-full sm:w-auto"
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading} className="w-full sm:w-auto">
+              {loading ? 'Saving...' : equipment ? 'Save Changes' : 'Add Equipment'}
+            </Button>
+          </SheetFooter>
+        </form>
+      </SheetContent>
+    </Sheet>
   )
 }

--- a/frontend/components/equipment/equipment-status-card.tsx
+++ b/frontend/components/equipment/equipment-status-card.tsx
@@ -4,7 +4,21 @@ import { cn } from '@/lib/utils'
 import { StatusBadge, type EquipmentStatus } from './status-badge'
 import type { EquipmentDomain } from '@/types/domain/equipment'
 
-const TYPE_ICONS: Record<string, string> = {
+export const EQUIPMENT_TYPES = [
+  'fuel_truck',
+  'tug',
+  'gpu',
+  'air_start',
+  'belt_loader',
+  'stairs',
+  'lavatory_service',
+  'water_service',
+  'golf_cart',
+  'staff_vehicle',
+  'other',
+] as const
+
+export const TYPE_ICONS: Record<string, string> = {
   fuel_truck:       '🚛',
   tug:              '🚜',
   gpu:              '⚡',
@@ -13,6 +27,8 @@ const TYPE_ICONS: Record<string, string> = {
   stairs:           '🪜',
   lavatory_service: '🚿',
   water_service:    '💧',
+  golf_cart:        '⛳',
+  staff_vehicle:    '🚗',
   other:            '🔧',
 }
 
@@ -23,7 +39,7 @@ const STATUS_BORDER: Record<string, string> = {
   out_of_service: 'border-l-red-500',
 }
 
-function formatTypeLabel(type: string): string {
+export function formatTypeLabel(type: string): string {
   return type.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
 }
 

--- a/frontend/types/database.ts
+++ b/frontend/types/database.ts
@@ -421,7 +421,7 @@ export type Database = {
           id: number
           equipment_id: string
           equipment_name: string
-          equipment_type: 'fuel_truck' | 'tug' | 'gpu' | 'air_start' | 'belt_loader' | 'stairs' | 'lavatory_service' | 'water_service' | 'other'
+          equipment_type: 'fuel_truck' | 'tug' | 'gpu' | 'air_start' | 'belt_loader' | 'stairs' | 'lavatory_service' | 'water_service' | 'golf_cart' | 'staff_vehicle' | 'other'
           manufacturer: string
           model: string
           serial_number: string
@@ -439,7 +439,7 @@ export type Database = {
           id?: number
           equipment_id: string
           equipment_name: string
-          equipment_type: 'fuel_truck' | 'tug' | 'gpu' | 'air_start' | 'belt_loader' | 'stairs' | 'lavatory_service' | 'water_service' | 'other'
+          equipment_type: 'fuel_truck' | 'tug' | 'gpu' | 'air_start' | 'belt_loader' | 'stairs' | 'lavatory_service' | 'water_service' | 'golf_cart' | 'staff_vehicle' | 'other'
           manufacturer?: string
           model?: string
           serial_number?: string


### PR DESCRIPTION
## Summary
- `frontend/types/database.ts`: add `golf_cart` and `staff_vehicle` to the `equipment_type` union (Row + Insert) to match the DB CHECK constraint, which already accepts these values (the `equipment` table, RLS, and 13 seed rows including golf cart `GC-1` and staff vehicles `VEH-MALIBU`/`VEH-SUBURBAN` were previously verified live against Supabase — no DB migration needed here).
- `frontend/components/equipment/equipment-status-card.tsx`: extend the existing `TYPE_ICONS` mapping with icons for the two new types and export it plus `EQUIPMENT_TYPES`/`formatTypeLabel` for reuse, rather than introducing a second type-label mapping.
- `frontend/components/equipment/equipment-form-dialog.tsx`: migrate from `Dialog` to `Sheet` (`side="right"`), matching the house-wide slideout convention used elsewhere (e.g. `parking/aircraft-sheet.tsx`, `fuel-farm/tank-form-dialog.tsx`); type/status fields now use the shared `Select` component instead of raw `<select>`.
- `frontend/app/equipment/page.tsx`: add a type filter dropdown above the status board, reusing `EQUIPMENT_TYPES`/`formatTypeLabel` from `equipment-status-card.tsx`.

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [ ] Manually verify in the browser: create/edit equipment as `golf_cart` and `staff_vehicle`, confirm icon/label render on the status card, confirm the type filter narrows the board correctly, confirm the Sheet slideout opens/closes and submits as before