### PR TITLE
feat: add user management module (roles, permissions, invites) — scoped port of #19

### DIFF
--- a/frontend/app/(account)/profile/page.tsx
+++ b/frontend/app/(account)/profile/page.tsx
@@ -1,30 +1,152 @@
-import { profileAction } from '@/actions/profile-action'
-import { ProfileForm } from '@/components/forms/profile-form'
-import { createClient } from '@/lib/supabase/server'
-import { findUserByEmail } from '@/repositories/users.repo'
-import type { Metadata } from 'next'
+'use client'
 
-export const metadata: Metadata = {
-  title: 'Profile - Turbo'
-}
+import { useMyProfile } from '@/hooks/use-my-profile'
+import { useMyPermissions } from '@/hooks/use-permissions'
+import { MODULES } from '@/types/domain/users'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { ErrorMessage } from '@/messages/error-message'
+import { SuccessMessage } from '@/messages/success-message'
+import { useEffect, useState } from 'react'
 
-export default async function Profile() {
-  const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+export default function ProfilePage() {
+  const { profile, loading, updateProfile } = useMyProfile()
+  const { access } = useMyPermissions()
 
-  const currentUserPromise = user?.email
-    ? findUserByEmail(supabase as any, user.email).then((u) => ({
-        first_name: u?.first_name ?? user.user_metadata?.first_name ?? '',
-        last_name: u?.last_name ?? user.user_metadata?.last_name ?? '',
-        email: u?.email ?? user.email ?? '',
-        username: u?.username ?? user.user_metadata?.username ?? ''
-      }))
-    : Promise.resolve({ first_name: '', last_name: '', email: '', username: '' })
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [phoneNumber, setPhoneNumber] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [success, setSuccess] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (!profile) return
+    setFirstName(profile.first_name)
+    setLastName(profile.last_name)
+    setPhoneNumber(profile.phone_number)
+  }, [profile])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setSuccess(false)
+    setSaving(true)
+    try {
+      await updateProfile({
+        first_name: firstName,
+        last_name: lastName,
+        phone_number: phoneNumber
+      })
+      setSuccess(true)
+    } catch {
+      setError('Failed to update profile. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="text-muted-foreground">Loading profile...</div>
+      </div>
+    )
+  }
+
+  if (!profile) {
+    return (
+      <ErrorMessage>
+        Could not load your profile. Try signing in again.
+      </ErrorMessage>
+    )
+  }
+
+  const grantedModules = MODULES.filter((m) => access[m.key])
 
   return (
-    <ProfileForm
-      currentUser={currentUserPromise as any}
-      onSubmitHandler={profileAction}
-    />
+    <div className="w-full rounded-lg border border-border bg-card p-6 shadow-sm space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">My Profile</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Update your basic information. Contact an administrator to change your
+          email, roles, or employee ID.
+        </p>
+      </div>
+
+      {success && <SuccessMessage>Profile updated successfully</SuccessMessage>}
+      {error && <ErrorMessage>{error}</ErrorMessage>}
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input id="email" value={profile.email} disabled />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="firstName">First Name</Label>
+            <Input
+              id="firstName"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="lastName">Last Name</Label>
+            <Input
+              id="lastName"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              required
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="phoneNumber">Phone Number</Label>
+          <Input
+            id="phoneNumber"
+            type="tel"
+            value={phoneNumber}
+            onChange={(e) => setPhoneNumber(e.target.value)}
+            placeholder="(555) 555-1234"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label>Employee ID</Label>
+          <Input value={profile.employee_id ?? 'Not assigned'} disabled />
+        </div>
+
+        <Button type="submit" disabled={saving}>
+          {saving ? 'Saving...' : 'Save Changes'}
+        </Button>
+      </form>
+
+      <div className="border-t border-border pt-4">
+        <h2 className="text-sm font-semibold text-foreground">Your Access</h2>
+        {grantedModules.length === 0 ? (
+          <p className="mt-2 text-sm text-muted-foreground">
+            No roles assigned yet — you don&apos;t have access to any module.
+            Contact an administrator.
+          </p>
+        ) : (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {grantedModules.map((m) => (
+              <Badge
+                key={m.key}
+                variant={access[m.key] === 'manage' ? 'default' : 'secondary'}
+              >
+                {m.label}: {access[m.key] === 'manage' ? 'Manage' : 'View'}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
   )
 }

--- a/frontend/app/api/users/[id]/route.ts
+++ b/frontend/app/api/users/[id]/route.ts
@@ -1,0 +1,35 @@
+import { createAdminClient } from '@/lib/supabase/admin'
+import { requireUsersAdmin } from '@/lib/supabase/require-users-admin'
+import { type NextRequest, NextResponse } from 'next/server'
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const authResult = await requireUsersAdmin()
+  if (!authResult.ok) {
+    return NextResponse.json(
+      { error: authResult.error },
+      { status: authResult.status }
+    )
+  }
+
+  const { id } = await params
+
+  if (id === authResult.caller.user.id) {
+    return NextResponse.json(
+      { error: 'You cannot delete your own account' },
+      { status: 400 }
+    )
+  }
+
+  const admin = createAdminClient()
+
+  // Deleting the auth user cascades to profiles/user_roles via FK ON DELETE CASCADE.
+  const { error } = await admin.auth.admin.deleteUser(id)
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/frontend/app/api/users/invite/route.ts
+++ b/frontend/app/api/users/invite/route.ts
@@ -1,0 +1,72 @@
+import { createAdminClient } from '@/lib/supabase/admin'
+import { requireUsersAdmin } from '@/lib/supabase/require-users-admin'
+import { setUserRoles } from '@/repositories/user-roles.repo'
+import { type NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  const authResult = await requireUsersAdmin()
+  if (!authResult.ok) {
+    return NextResponse.json(
+      { error: authResult.error },
+      { status: authResult.status }
+    )
+  }
+
+  const body = await request.json()
+  const { email, firstName, lastName, phoneNumber, employeeId, roleIds } =
+    body as {
+      email?: string
+      firstName?: string
+      lastName?: string
+      phoneNumber?: string
+      employeeId?: string
+      roleIds?: number[]
+    }
+
+  if (!email || typeof email !== 'string') {
+    return NextResponse.json({ error: 'Email is required' }, { status: 400 })
+  }
+
+  const admin = createAdminClient()
+
+  const { data: invited, error: inviteError } =
+    await admin.auth.admin.inviteUserByEmail(email, {
+      data: { first_name: firstName ?? '', last_name: lastName ?? '' },
+      redirectTo: process.env.NEXT_PUBLIC_SITE_URL
+        ? `${process.env.NEXT_PUBLIC_SITE_URL}/login`
+        : undefined
+    })
+
+  if (inviteError || !invited.user) {
+    return NextResponse.json(
+      { error: inviteError?.message ?? 'Failed to invite user' },
+      { status: 400 }
+    )
+  }
+
+  const newUserId = invited.user.id
+
+  // The auth trigger already created a bare profiles row; fill in the
+  // details the admin provided on the invite form.
+  const { error: profileError } = await admin
+    .from('profiles')
+    .update({
+      first_name: firstName ?? '',
+      last_name: lastName ?? '',
+      phone_number: phoneNumber ?? '',
+      employee_id: employeeId ?? null,
+      created_by: authResult.caller.user.id,
+      updated_by: authResult.caller.user.id
+    })
+    .eq('id', newUserId)
+
+  if (profileError) {
+    return NextResponse.json({ error: profileError.message }, { status: 400 })
+  }
+
+  if (roleIds && roleIds.length > 0) {
+    await setUserRoles(admin, newUserId, roleIds, authResult.caller.user.id)
+  }
+
+  return NextResponse.json({ id: newUserId, email }, { status: 201 })
+}

--- a/frontend/app/users/page.tsx
+++ b/frontend/app/users/page.tsx
@@ -1,0 +1,369 @@
+'use client'
+
+import { type UserFormData, UserSheet } from '@/components/users/user-sheet'
+import { useModuleAccess } from '@/hooks/use-permissions'
+import { useRoles } from '@/hooks/use-roles'
+import { useUsers } from '@/hooks/use-users'
+import type { ProfileWithRoles } from '@/types/domain/users'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from '@/components/ui/table'
+import { ErrorMessage } from '@/messages/error-message'
+import { SuccessMessage } from '@/messages/success-message'
+import { MoreHorizontal } from 'lucide-react'
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+
+export default function UsersPage() {
+  const { allowed, loading: accessLoading } = useModuleAccess('users', 'manage')
+  const {
+    users,
+    loading,
+    error,
+    inviteUser,
+    updateUser,
+    setUserStatus,
+    deleteUser,
+    refetch
+  } = useUsers()
+  const { roles } = useRoles()
+
+  const [search, setSearch] = useState('')
+  const [statusFilter, setStatusFilter] = useState<
+    'all' | 'active' | 'disabled'
+  >('all')
+  const [roleFilter, setRoleFilter] = useState<string>('all')
+
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const [editingUser, setEditingUser] = useState<ProfileWithRoles | null>(null)
+  const [successMessage, setSuccessMessage] = useState('')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const showSuccess = (msg: string) => {
+    setSuccessMessage(msg)
+    setTimeout(() => setSuccessMessage(''), 3000)
+  }
+  const showError = (msg: string) => {
+    setErrorMessage(msg)
+    setTimeout(() => setErrorMessage(''), 5000)
+  }
+
+  const filteredUsers = useMemo(() => {
+    return users.filter((u) => {
+      if (statusFilter !== 'all' && u.status !== statusFilter) return false
+      if (
+        roleFilter !== 'all' &&
+        !u.roles.some((r) => String(r.id) === roleFilter)
+      )
+        return false
+      if (search) {
+        const q = search.toLowerCase()
+        const haystack =
+          `${u.first_name} ${u.last_name} ${u.email} ${u.employee_id ?? ''}`.toLowerCase()
+        if (!haystack.includes(q)) return false
+      }
+      return true
+    })
+  }, [users, search, statusFilter, roleFilter])
+
+  const handleSubmit = async (data: UserFormData) => {
+    if (editingUser) {
+      await updateUser(editingUser.id, {
+        firstName: data.firstName,
+        lastName: data.lastName,
+        phoneNumber: data.phoneNumber,
+        employeeId: data.employeeId,
+        roleIds: data.roleIds
+      })
+      showSuccess('User updated')
+    } else {
+      await inviteUser({
+        email: data.email,
+        firstName: data.firstName,
+        lastName: data.lastName,
+        phoneNumber: data.phoneNumber,
+        employeeId: data.employeeId,
+        roleIds: data.roleIds
+      })
+      showSuccess(`Invitation sent to ${data.email}`)
+    }
+    refetch()
+  }
+
+  const handleToggleStatus = async (user: ProfileWithRoles) => {
+    const next = user.status === 'active' ? 'disabled' : 'active'
+    try {
+      await setUserStatus(user.id, next)
+      showSuccess(next === 'active' ? 'User reactivated' : 'User deactivated')
+    } catch {
+      showError('Failed to update user status')
+    }
+  }
+
+  const handleDelete = async (user: ProfileWithRoles) => {
+    if (
+      !confirm(
+        `Permanently delete ${user.first_name} ${user.last_name}? This cannot be undone.`
+      )
+    ) {
+      return
+    }
+    try {
+      await deleteUser(user.id)
+      showSuccess('User deleted')
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Failed to delete user')
+    }
+  }
+
+  if (accessLoading || loading) {
+    return (
+      <div className="flex items-center justify-center h-96">
+        <div className="text-lg text-muted-foreground">Loading users...</div>
+      </div>
+    )
+  }
+
+  if (!allowed) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-8 text-center">
+        <h1 className="text-xl font-semibold text-foreground">
+          Access Restricted
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          You do not have permission to manage users. Contact an administrator
+          if you believe this is a mistake.
+        </p>
+      </div>
+    )
+  }
+
+  const activeCount = users.filter((u) => u.status === 'active').length
+  const disabledCount = users.filter((u) => u.status === 'disabled').length
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-foreground">Users</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Manage staff accounts, roles, and module access
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" asChild>
+            <Link href="/users/roles">Roles &amp; Permissions</Link>
+          </Button>
+          <Button
+            className="bg-primary text-primary-foreground hover:bg-primary/90"
+            onClick={() => {
+              setEditingUser(null)
+              setSheetOpen(true)
+            }}
+          >
+            Invite User
+          </Button>
+        </div>
+      </div>
+
+      {successMessage && <SuccessMessage>{successMessage}</SuccessMessage>}
+      {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+      {error && <ErrorMessage>Failed to load users</ErrorMessage>}
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className="rounded-lg bg-card px-4 py-5 shadow-sm border border-border">
+          <div className="text-sm font-medium text-muted-foreground">
+            Total Users
+          </div>
+          <div className="mt-2 text-3xl font-bold text-foreground">
+            {users.length}
+          </div>
+        </div>
+        <div className="rounded-lg bg-card px-4 py-5 shadow-sm border border-border">
+          <div className="text-sm font-medium text-muted-foreground">
+            Active
+          </div>
+          <div className="mt-2 text-3xl font-bold text-success">
+            {activeCount}
+          </div>
+        </div>
+        <div className="rounded-lg bg-card px-4 py-5 shadow-sm border border-border">
+          <div className="text-sm font-medium text-muted-foreground">
+            Disabled
+          </div>
+          <div className="mt-2 text-3xl font-bold text-muted-foreground">
+            {disabledCount}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <Input
+          placeholder="Search by name, email, or employee ID..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="sm:max-w-xs"
+        />
+        <Select
+          value={statusFilter}
+          onValueChange={(v) => setStatusFilter(v as typeof statusFilter)}
+        >
+          <SelectTrigger className="sm:w-40">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            <SelectItem value="active">Active</SelectItem>
+            <SelectItem value="disabled">Disabled</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={roleFilter} onValueChange={setRoleFilter}>
+          <SelectTrigger className="sm:w-48">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All roles</SelectItem>
+            {roles.map((role) => (
+              <SelectItem key={role.id} value={String(role.id)}>
+                {role.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="rounded-lg bg-card shadow border border-border overflow-hidden">
+        {filteredUsers.length === 0 ? (
+          <div className="p-8 text-center">
+            <div className="text-muted-foreground">
+              {users.length === 0
+                ? 'No users found. Invite someone to get started.'
+                : 'No users match your search or filters.'}
+            </div>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Roles</TableHead>
+                  <TableHead>Employee ID</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="w-12" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredUsers.map((user) => (
+                  <TableRow key={user.id}>
+                    <TableCell className="font-medium text-foreground">
+                      {user.first_name || user.last_name ? (
+                        `${user.first_name} ${user.last_name}`.trim()
+                      ) : (
+                        <span className="text-muted-foreground italic">
+                          Pending signup
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {user.email}
+                    </TableCell>
+                    <TableCell>
+                      {user.roles.length === 0 ? (
+                        <span className="text-xs text-muted-foreground">
+                          No roles
+                        </span>
+                      ) : (
+                        <div className="flex flex-wrap gap-1">
+                          {user.roles.map((role) => (
+                            <Badge key={role.id} variant="secondary">
+                              {role.name}
+                            </Badge>
+                          ))}
+                        </div>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {user.employee_id || '—'}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={
+                          user.status === 'active' ? 'default' : 'outline'
+                        }
+                      >
+                        {user.status === 'active' ? 'Active' : 'Disabled'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="icon">
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={() => {
+                              setEditingUser(user)
+                              setSheetOpen(true)
+                            }}
+                          >
+                            Edit
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => handleToggleStatus(user)}
+                          >
+                            {user.status === 'active'
+                              ? 'Deactivate'
+                              : 'Reactivate'}
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            className="text-destructive focus:text-destructive"
+                            onClick={() => handleDelete(user)}
+                          >
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+
+      <UserSheet
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+        user={editingUser}
+        roles={roles}
+        onSubmit={handleSubmit}
+      />
+    </div>
+  )
+}

--- a/frontend/app/users/roles/page.tsx
+++ b/frontend/app/users/roles/page.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import { type RoleFormData, RoleSheet } from '@/components/roles/role-sheet'
+import { useModuleAccess } from '@/hooks/use-permissions'
+import { useRoles } from '@/hooks/use-roles'
+import { MODULES, type RoleWithPermissions } from '@/types/domain/users'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { ErrorMessage } from '@/messages/error-message'
+import { SuccessMessage } from '@/messages/success-message'
+import { ArrowLeft } from 'lucide-react'
+import Link from 'next/link'
+import { useState } from 'react'
+
+export default function RolesPage() {
+  const { allowed, loading: accessLoading } = useModuleAccess('users', 'manage')
+  const { roles, loading, error, createRole, updateRole, deleteRole, refetch } =
+    useRoles()
+
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const [editingRole, setEditingRole] = useState<RoleWithPermissions | null>(
+    null
+  )
+  const [successMessage, setSuccessMessage] = useState('')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const showSuccess = (msg: string) => {
+    setSuccessMessage(msg)
+    setTimeout(() => setSuccessMessage(''), 3000)
+  }
+  const showError = (msg: string) => {
+    setErrorMessage(msg)
+    setTimeout(() => setErrorMessage(''), 5000)
+  }
+
+  const handleSubmit = async (data: RoleFormData) => {
+    if (editingRole) {
+      await updateRole(
+        editingRole.id,
+        { description: data.description },
+        data.permissions
+      )
+      showSuccess('Role updated')
+    } else {
+      await createRole(
+        { name: data.name, description: data.description },
+        data.permissions
+      )
+      showSuccess('Role created')
+    }
+    refetch()
+  }
+
+  const handleDelete = async (role: RoleWithPermissions) => {
+    if (role.is_system) return
+    if (
+      !confirm(
+        `Delete the "${role.name}" role? Anyone holding it will lose its access.`
+      )
+    )
+      return
+    try {
+      await deleteRole(role.id)
+      showSuccess('Role deleted')
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'Failed to delete role')
+    }
+  }
+
+  if (accessLoading || loading) {
+    return (
+      <div className="flex items-center justify-center h-96">
+        <div className="text-lg text-muted-foreground">Loading roles...</div>
+      </div>
+    )
+  }
+
+  if (!allowed) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-8 text-center">
+        <h1 className="text-xl font-semibold text-foreground">
+          Access Restricted
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          You do not have permission to manage roles.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <Link
+            href="/users"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" /> Back to Users
+          </Link>
+          <h1 className="mt-2 text-3xl font-bold text-foreground">
+            Roles &amp; Permissions
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Define what each role can see and change, per module
+          </p>
+        </div>
+        <Button
+          className="bg-primary text-primary-foreground hover:bg-primary/90"
+          onClick={() => {
+            setEditingRole(null)
+            setSheetOpen(true)
+          }}
+        >
+          New Role
+        </Button>
+      </div>
+
+      {successMessage && <SuccessMessage>{successMessage}</SuccessMessage>}
+      {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+      {error && <ErrorMessage>Failed to load roles</ErrorMessage>}
+
+      {roles.length === 0 ? (
+        <div className="rounded-lg bg-card shadow border border-border p-8 text-center">
+          <div className="text-muted-foreground">
+            No roles found. Create one to get started.
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {roles.map((role) => (
+            <div
+              key={role.id}
+              className="rounded-lg bg-card shadow-sm border border-border p-5 flex flex-col gap-3"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <h2 className="text-lg font-semibold text-foreground">
+                      {role.name}
+                    </h2>
+                    {role.is_system && (
+                      <Badge variant="outline">Built-in</Badge>
+                    )}
+                  </div>
+                  {role.description && (
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {role.description}
+                    </p>
+                  )}
+                </div>
+                <div className="flex shrink-0 gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setEditingRole(role)
+                      setSheetOpen(true)
+                    }}
+                  >
+                    Edit
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="text-destructive hover:text-destructive"
+                    disabled={role.is_system}
+                    title={
+                      role.is_system
+                        ? 'Built-in roles cannot be deleted'
+                        : undefined
+                    }
+                    onClick={() => handleDelete(role)}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-1.5">
+                {MODULES.map((mod) => {
+                  const perm = role.permissions.find(
+                    (p) => p.module === mod.key
+                  )
+                  if (!perm) return null
+                  return (
+                    <Badge
+                      key={mod.key}
+                      variant={
+                        perm.access_level === 'manage' ? 'default' : 'secondary'
+                      }
+                    >
+                      {mod.label}:{' '}
+                      {perm.access_level === 'manage' ? 'Manage' : 'View'}
+                    </Badge>
+                  )
+                })}
+                {role.permissions.length === 0 && (
+                  <span className="text-xs text-muted-foreground">
+                    No module access granted
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <RoleSheet
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+        role={editingRole}
+        onSubmit={handleSubmit}
+      />
+    </div>
+  )
+}

--- a/frontend/components/navigation.tsx
+++ b/frontend/components/navigation.tsx
@@ -1,10 +1,17 @@
 'use client'
 
+import { useAuth } from '@/providers/auth-provider'
 import { Button } from '@/components/ui/button'
-import { Moon, Sun } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Moon, Sun, User } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
-import { useAuth } from '@/providers/auth-provider'
 
 const navigation = [
   { name: 'Flight Ops', href: '/' },
@@ -15,7 +22,8 @@ const navigation = [
   { name: 'Invoicing', href: '/invoicing' },
   { name: 'Equipment', href: '/equipment' },
   { name: 'Line Schedule', href: '/line-schedule' },
-  { name: 'Training', href: '/training' }
+  { name: 'Training', href: '/training' },
+  { name: 'Users', href: '/users' }
 ]
 
 interface NavigationProps {
@@ -80,13 +88,26 @@ export function Navigation({ theme = 'dark', onThemeChange }: NavigationProps) {
                 )}
               </Button>
             )}
-            <Button
-              variant="outline"
-              onClick={handleSignOut}
-              className="text-foreground"
-            >
-              Sign out
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="text-foreground"
+                >
+                  <User className="h-5 w-5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem asChild>
+                  <Link href="/profile">Profile</Link>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleSignOut}>
+                  Sign out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
       </div>

--- a/frontend/components/roles/role-sheet.tsx
+++ b/frontend/components/roles/role-sheet.tsx
@@ -1,0 +1,195 @@
+'use client'
+
+import {
+  type AccessLevel,
+  MODULES,
+  type ModuleKey,
+  type RoleWithPermissions
+} from '@/types/domain/users'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle
+} from '@/components/ui/sheet'
+import { Textarea } from '@/components/ui/textarea'
+import { ErrorMessage } from '@/messages/error-message'
+import { useEffect, useState } from 'react'
+
+export type PermissionGrid = Partial<Record<ModuleKey, AccessLevel | null>>
+
+export interface RoleFormData {
+  name: string
+  description: string
+  permissions: PermissionGrid
+}
+
+function emptyGrid(): PermissionGrid {
+  return Object.fromEntries(MODULES.map((m) => [m.key, null])) as PermissionGrid
+}
+
+interface RoleSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  role?: RoleWithPermissions | null
+  onSubmit: (data: RoleFormData) => Promise<void>
+}
+
+export function RoleSheet({
+  open,
+  onOpenChange,
+  role,
+  onSubmit
+}: RoleSheetProps) {
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [permissions, setPermissions] = useState<PermissionGrid>(emptyGrid())
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (!open) return
+    setError('')
+    if (role) {
+      setName(role.name)
+      setDescription(role.description)
+      const grid = emptyGrid()
+      for (const perm of role.permissions) {
+        grid[perm.module] = perm.access_level
+      }
+      setPermissions(grid)
+    } else {
+      setName('')
+      setDescription('')
+      setPermissions(emptyGrid())
+    }
+  }, [role, open])
+
+  const setModuleAccess = (module: ModuleKey, value: string) => {
+    setPermissions((prev) => ({
+      ...prev,
+      [module]: value === 'none' ? null : (value as AccessLevel)
+    }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setLoading(true)
+    try {
+      await onSubmit({ name, description, permissions })
+      onOpenChange(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save role')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const isSystemRole = !!role?.is_system
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full sm:max-w-lg overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>{role ? 'Edit Role' : 'New Role'}</SheetTitle>
+          <SheetDescription>
+            Choose the access level this role grants per module. "Manage"
+            includes full read/write; "View" is read-only; leave a module unset
+            to hide it entirely.
+          </SheetDescription>
+        </SheetHeader>
+
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-1 flex-col gap-4 overflow-y-auto px-4"
+        >
+          {error && <ErrorMessage>{error}</ErrorMessage>}
+
+          <div className="space-y-2">
+            <Label htmlFor="role-name">Role Name *</Label>
+            <Input
+              id="role-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              disabled={isSystemRole}
+              placeholder="e.g., Ramp Supervisor"
+            />
+            {isSystemRole && (
+              <p className="text-xs text-muted-foreground">
+                Built-in role names cannot be changed, but permissions can.
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="role-description">Description</Label>
+            <Textarea
+              id="role-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={2}
+              placeholder="What this role is for"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Module Access</Label>
+            <div className="rounded-md border border-border divide-y divide-border">
+              {MODULES.map((mod) => (
+                <div
+                  key={mod.key}
+                  className="flex items-center justify-between gap-4 p-3"
+                >
+                  <span className="text-sm font-medium text-foreground">
+                    {mod.label}
+                  </span>
+                  <Select
+                    value={permissions[mod.key] ?? 'none'}
+                    onValueChange={(v) => setModuleAccess(mod.key, v)}
+                  >
+                    <SelectTrigger className="w-36">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">No access</SelectItem>
+                      <SelectItem value="view">View only</SelectItem>
+                      <SelectItem value="manage">Manage</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <SheetFooter className="mt-auto flex-row justify-end gap-2 px-0">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Saving...' : role ? 'Save Changes' : 'Create Role'}
+            </Button>
+          </SheetFooter>
+        </form>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/frontend/components/users/user-sheet.tsx
+++ b/frontend/components/users/user-sheet.tsx
@@ -1,0 +1,239 @@
+'use client'
+
+import type { ProfileWithRoles } from '@/types/domain/users'
+import type { RoleWithPermissions } from '@/types/domain/users'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle
+} from '@/components/ui/sheet'
+import { ErrorMessage } from '@/messages/error-message'
+import { useEffect, useState } from 'react'
+
+export interface UserFormData {
+  email: string
+  firstName: string
+  lastName: string
+  phoneNumber: string
+  employeeId: string
+  roleIds: number[]
+}
+
+const EMPTY_FORM: UserFormData = {
+  email: '',
+  firstName: '',
+  lastName: '',
+  phoneNumber: '',
+  employeeId: '',
+  roleIds: []
+}
+
+interface UserSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  user?: ProfileWithRoles | null
+  roles: RoleWithPermissions[]
+  onSubmit: (data: UserFormData) => Promise<void>
+}
+
+export function UserSheet({
+  open,
+  onOpenChange,
+  user,
+  roles,
+  onSubmit
+}: UserSheetProps) {
+  const [formData, setFormData] = useState<UserFormData>(EMPTY_FORM)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (!open) return
+    setError('')
+    if (user) {
+      setFormData({
+        email: user.email,
+        firstName: user.first_name,
+        lastName: user.last_name,
+        phoneNumber: user.phone_number,
+        employeeId: user.employee_id ?? '',
+        roleIds: user.roles.map((r) => r.id)
+      })
+    } else {
+      setFormData(EMPTY_FORM)
+    }
+  }, [user, open])
+
+  const toggleRole = (roleId: number) => {
+    setFormData((prev) => ({
+      ...prev,
+      roleIds: prev.roleIds.includes(roleId)
+        ? prev.roleIds.filter((id) => id !== roleId)
+        : [...prev.roleIds, roleId]
+    }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setLoading(true)
+    try {
+      await onSubmit(formData)
+      onOpenChange(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save user')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full sm:max-w-lg overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>{user ? 'Edit User' : 'Invite User'}</SheetTitle>
+          <SheetDescription>
+            {user
+              ? 'Update this person’s details and role assignments.'
+              : 'An email invitation will be sent so they can set their own password.'}
+          </SheetDescription>
+        </SheetHeader>
+
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-1 flex-col gap-4 overflow-y-auto px-4"
+        >
+          {error && <ErrorMessage>{error}</ErrorMessage>}
+
+          <div className="space-y-2">
+            <Label htmlFor="email">Email *</Label>
+            <Input
+              id="email"
+              type="email"
+              value={formData.email}
+              onChange={(e) =>
+                setFormData({ ...formData, email: e.target.value })
+              }
+              required
+              disabled={!!user}
+              placeholder="name@example.com"
+            />
+            {user && (
+              <p className="text-xs text-muted-foreground">
+                Email cannot be changed here.
+              </p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="firstName">First Name *</Label>
+              <Input
+                id="firstName"
+                value={formData.firstName}
+                onChange={(e) =>
+                  setFormData({ ...formData, firstName: e.target.value })
+                }
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="lastName">Last Name *</Label>
+              <Input
+                id="lastName"
+                value={formData.lastName}
+                onChange={(e) =>
+                  setFormData({ ...formData, lastName: e.target.value })
+                }
+                required
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="phoneNumber">Phone Number</Label>
+              <Input
+                id="phoneNumber"
+                type="tel"
+                value={formData.phoneNumber}
+                onChange={(e) =>
+                  setFormData({ ...formData, phoneNumber: e.target.value })
+                }
+                placeholder="(555) 555-1234"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="employeeId">Employee ID</Label>
+              <Input
+                id="employeeId"
+                value={formData.employeeId}
+                onChange={(e) =>
+                  setFormData({ ...formData, employeeId: e.target.value })
+                }
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Roles</Label>
+            {roles.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No roles exist yet. Create one under Users &rarr; Roles.
+              </p>
+            ) : (
+              <div className="space-y-2 rounded-md border border-border p-3">
+                {roles.map((role) => {
+                  const inputId = `role-${role.id}`
+                  return (
+                    <div
+                      key={role.id}
+                      className="flex items-start gap-2 text-sm"
+                    >
+                      <Checkbox
+                        id={inputId}
+                        checked={formData.roleIds.includes(role.id)}
+                        onCheckedChange={() => toggleRole(role.id)}
+                      />
+                      <Label htmlFor={inputId} className="font-normal">
+                        <span className="font-medium text-foreground">
+                          {role.name}
+                        </span>
+                        {role.description && (
+                          <span className="block text-xs text-muted-foreground">
+                            {role.description}
+                          </span>
+                        )}
+                      </Label>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+
+          <SheetFooter className="mt-auto flex-row justify-end gap-2 px-0">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Saving...' : user ? 'Save Changes' : 'Send Invite'}
+            </Button>
+          </SheetFooter>
+        </form>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/frontend/hooks/use-my-profile.ts
+++ b/frontend/hooks/use-my-profile.ts
@@ -1,0 +1,43 @@
+'use client'
+
+import { createClient } from '@/lib/supabase/client'
+import { useAuth } from '@/providers/auth-provider'
+import { findProfileById, updateProfile } from '@/repositories/profiles.repo'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+export function useMyProfile() {
+  const qc = useQueryClient()
+  const db = createClient()
+  const { session } = useAuth()
+  const userId = session?.user?.id
+
+  const query = useQuery({
+    queryKey: ['my-profile', userId],
+    queryFn: () => findProfileById(db, userId as string),
+    enabled: !!userId
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: (updates: {
+      first_name: string
+      last_name: string
+      phone_number: string
+    }) =>
+      updateProfile(db, userId as string, { ...updates, updated_by: userId }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['my-profile', userId] })
+      qc.invalidateQueries({ queryKey: ['current-user'] })
+    }
+  })
+
+  return {
+    profile: query.data ?? null,
+    loading: session === undefined || query.isLoading,
+    error: query.error,
+    updateProfile: (updates: {
+      first_name: string
+      last_name: string
+      phone_number: string
+    }) => updateMutation.mutateAsync(updates)
+  }
+}

--- a/frontend/hooks/use-permissions.ts
+++ b/frontend/hooks/use-permissions.ts
@@ -1,0 +1,39 @@
+'use client'
+
+import { createClient } from '@/lib/supabase/client'
+import { useAuth } from '@/providers/auth-provider'
+import { findModuleAccessForUser } from '@/repositories/user-roles.repo'
+import {
+  type AccessLevel,
+  type ModuleKey,
+  accessAtLeast
+} from '@/types/domain/users'
+import { useQuery } from '@tanstack/react-query'
+
+/** The current user's effective per-module access, resolved from their roles. */
+export function useMyPermissions() {
+  const { session } = useAuth()
+  const db = createClient()
+  const userId = session?.user?.id
+
+  const query = useQuery({
+    queryKey: ['my-permissions', userId],
+    queryFn: () => findModuleAccessForUser(db, userId as string),
+    enabled: !!userId
+  })
+
+  return {
+    access: query.data ?? {},
+    loading: session === undefined || query.isLoading,
+    refetch: query.refetch
+  }
+}
+
+/** Convenience check for a single module, e.g. useModuleAccess('users', 'manage'). */
+export function useModuleAccess(module: ModuleKey, min: AccessLevel = 'view') {
+  const { access, loading } = useMyPermissions()
+  return {
+    allowed: accessAtLeast(access, module, min),
+    loading
+  }
+}

--- a/frontend/hooks/use-roles.ts
+++ b/frontend/hooks/use-roles.ts
@@ -1,0 +1,82 @@
+'use client'
+
+import { createClient } from '@/lib/supabase/client'
+import {
+  type RoleInsert,
+  type RoleUpdate,
+  createRole,
+  deleteRole,
+  findAllRoles,
+  setRolePermissions,
+  updateRole
+} from '@/repositories/roles.repo'
+import type { AccessLevel, ModuleKey } from '@/types/domain/users'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+export const roleKeys = {
+  all: ['roles'] as const,
+  lists: () => [...roleKeys.all, 'list'] as const
+}
+
+export function useRoles() {
+  const qc = useQueryClient()
+  const db = createClient()
+
+  const query = useQuery({
+    queryKey: roleKeys.lists(),
+    queryFn: () => findAllRoles(db)
+  })
+
+  const createMutation = useMutation({
+    mutationFn: async ({
+      role,
+      permissions
+    }: {
+      role: RoleInsert
+      permissions: Partial<Record<ModuleKey, AccessLevel | null>>
+    }) => {
+      const created = await createRole(db, role)
+      await setRolePermissions(db, created.id, permissions)
+      return created
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: roleKeys.all })
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: async ({
+      roleId,
+      updates,
+      permissions
+    }: {
+      roleId: number
+      updates: RoleUpdate
+      permissions: Partial<Record<ModuleKey, AccessLevel | null>>
+    }) => {
+      await updateRole(db, roleId, updates)
+      await setRolePermissions(db, roleId, permissions)
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: roleKeys.all })
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (roleId: number) => deleteRole(db, roleId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: roleKeys.all })
+  })
+
+  return {
+    roles: query.data ?? [],
+    loading: query.isLoading,
+    error: query.error,
+    createRole: (
+      role: RoleInsert,
+      permissions: Partial<Record<ModuleKey, AccessLevel | null>>
+    ) => createMutation.mutateAsync({ role, permissions }),
+    updateRole: (
+      roleId: number,
+      updates: RoleUpdate,
+      permissions: Partial<Record<ModuleKey, AccessLevel | null>>
+    ) => updateMutation.mutateAsync({ roleId, updates, permissions }),
+    deleteRole: (roleId: number) => deleteMutation.mutateAsync(roleId),
+    refetch: query.refetch
+  }
+}

--- a/frontend/hooks/use-users.ts
+++ b/frontend/hooks/use-users.ts
@@ -1,0 +1,72 @@
+'use client'
+
+import { createClient } from '@/lib/supabase/client'
+import { useAuth } from '@/providers/auth-provider'
+import { findAllProfiles } from '@/repositories/profiles.repo'
+import {
+  type InviteUserInput,
+  type UpdateUserInput,
+  deleteUser,
+  inviteUser,
+  setUserActiveStatus,
+  updateUserWithRoles
+} from '@/services/user-management.service'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+export const userKeys = {
+  all: ['users'] as const,
+  lists: () => [...userKeys.all, 'list'] as const
+}
+
+export function useUsers() {
+  const qc = useQueryClient()
+  const db = createClient()
+  const { session } = useAuth()
+  const currentUserId = session?.user?.id ?? null
+
+  const query = useQuery({
+    queryKey: userKeys.lists(),
+    queryFn: () => findAllProfiles(db)
+  })
+
+  const inviteMutation = useMutation({
+    mutationFn: (input: InviteUserInput) => inviteUser(input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: userKeys.all })
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: ({
+      userId,
+      input
+    }: { userId: string; input: UpdateUserInput }) =>
+      updateUserWithRoles(db, userId, input, currentUserId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: userKeys.all })
+  })
+
+  const setStatusMutation = useMutation({
+    mutationFn: ({
+      userId,
+      status
+    }: { userId: string; status: 'active' | 'disabled' }) =>
+      setUserActiveStatus(db, userId, status, currentUserId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: userKeys.all })
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (userId: string) => deleteUser(userId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: userKeys.all })
+  })
+
+  return {
+    users: query.data ?? [],
+    loading: query.isLoading,
+    error: query.error,
+    inviteUser: (input: InviteUserInput) => inviteMutation.mutateAsync(input),
+    updateUser: (userId: string, input: UpdateUserInput) =>
+      updateMutation.mutateAsync({ userId, input }),
+    setUserStatus: (userId: string, status: 'active' | 'disabled') =>
+      setStatusMutation.mutateAsync({ userId, status }),
+    deleteUser: (userId: string) => deleteMutation.mutateAsync(userId),
+    refetch: query.refetch
+  }
+}

--- a/frontend/lib/supabase/admin.ts
+++ b/frontend/lib/supabase/admin.ts
@@ -1,0 +1,26 @@
+import type { Database } from '@/types/database'
+import { createClient as createSupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * Service-role Supabase client. Bypasses RLS entirely — server-only.
+ * Never import this from a 'use client' component or expose it to the browser.
+ * Used for admin operations (auth.admin.*) that the anon key cannot perform,
+ * e.g. inviting or deleting a Supabase auth user.
+ */
+export function createAdminClient() {
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!serviceRoleKey) {
+    throw new Error('SUPABASE_SERVICE_ROLE_KEY is not configured')
+  }
+
+  return createSupabaseClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    serviceRoleKey,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false
+      }
+    }
+  )
+}

--- a/frontend/lib/supabase/require-users-admin.ts
+++ b/frontend/lib/supabase/require-users-admin.ts
@@ -1,0 +1,39 @@
+import { createClient } from '@/lib/supabase/server'
+import { findModuleAccessForUser } from '@/repositories/user-roles.repo'
+import { accessAtLeast } from '@/types/domain/users'
+import type { User } from '@supabase/supabase-js'
+
+interface AuthorizedCaller {
+  user: User
+}
+
+/**
+ * Verifies the current request is from an authenticated user who holds
+ * 'manage' access on the 'users' module. Route handlers that perform
+ * admin-only user-management actions (invite, delete) must call this
+ * before touching the service-role client.
+ */
+export async function requireUsersAdmin(): Promise<
+  | { ok: true; caller: AuthorizedCaller }
+  | { ok: false; status: number; error: string }
+> {
+  const supabase = await createClient()
+  const {
+    data: { user }
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { ok: false, status: 401, error: 'Not authenticated' }
+  }
+
+  const access = await findModuleAccessForUser(supabase as any, user.id)
+  if (!accessAtLeast(access, 'users', 'manage')) {
+    return {
+      ok: false,
+      status: 403,
+      error: 'You do not have permission to manage users'
+    }
+  }
+
+  return { ok: true, caller: { user } }
+}

--- a/frontend/repositories/profiles.repo.ts
+++ b/frontend/repositories/profiles.repo.ts
@@ -1,0 +1,63 @@
+import type { Database, Tables, TablesUpdate } from '@/types/database'
+import type { ProfileWithRoles } from '@/types/domain/users'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type ProfileRow = Tables<'profiles'>
+export type ProfileUpdate = TablesUpdate<'profiles'>
+
+const PROFILE_WITH_ROLES_SELECT = `
+  *,
+  roles:user_roles(role:roles(*))
+`
+
+function mapProfileWithRoles(row: any): ProfileWithRoles {
+  const roles = (row.roles ?? []).map((ur: any) => ur.role).filter(Boolean)
+  return { ...row, roles }
+}
+
+export async function findAllProfiles(
+  db: SupabaseClient<Database>
+): Promise<ProfileWithRoles[]> {
+  const { data, error } = await db
+    .from('profiles')
+    .select(PROFILE_WITH_ROLES_SELECT)
+    .order('last_name')
+  if (error) throw error
+  return (data ?? []).map(mapProfileWithRoles)
+}
+
+export async function findProfileById(
+  db: SupabaseClient<Database>,
+  id: string
+): Promise<ProfileWithRoles | null> {
+  const { data, error } = await db
+    .from('profiles')
+    .select(PROFILE_WITH_ROLES_SELECT)
+    .eq('id', id)
+    .single()
+  if (error && error.code !== 'PGRST116') throw error
+  return data ? mapProfileWithRoles(data) : null
+}
+
+export async function updateProfile(
+  db: SupabaseClient<Database>,
+  id: string,
+  updates: ProfileUpdate
+): Promise<ProfileRow> {
+  const { data, error } = await db
+    .from('profiles')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single()
+  if (error) throw error
+  return data
+}
+
+export async function deleteProfile(
+  db: SupabaseClient<Database>,
+  id: string
+): Promise<void> {
+  const { error } = await db.from('profiles').delete().eq('id', id)
+  if (error) throw error
+}

--- a/frontend/repositories/roles.repo.ts
+++ b/frontend/repositories/roles.repo.ts
@@ -1,0 +1,101 @@
+import type {
+  Database,
+  Tables,
+  TablesInsert,
+  TablesUpdate
+} from '@/types/database'
+import type {
+  AccessLevel,
+  ModuleKey,
+  RoleWithPermissions
+} from '@/types/domain/users'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type RoleRow = Tables<'roles'>
+export type RoleInsert = TablesInsert<'roles'>
+export type RoleUpdate = TablesUpdate<'roles'>
+export type ModulePermissionRow = Tables<'module_permissions'>
+
+export async function findAllRoles(
+  db: SupabaseClient<Database>
+): Promise<RoleWithPermissions[]> {
+  const { data, error } = await db
+    .from('roles')
+    .select('*, permissions:module_permissions(*)')
+    .order('name')
+  if (error) throw error
+  return (data ?? []) as unknown as RoleWithPermissions[]
+}
+
+export async function findRoleById(
+  db: SupabaseClient<Database>,
+  id: number
+): Promise<RoleWithPermissions | null> {
+  const { data, error } = await db
+    .from('roles')
+    .select('*, permissions:module_permissions(*)')
+    .eq('id', id)
+    .single()
+  if (error && error.code !== 'PGRST116') throw error
+  return data as unknown as RoleWithPermissions | null
+}
+
+export async function createRole(
+  db: SupabaseClient<Database>,
+  role: RoleInsert
+): Promise<RoleRow> {
+  const { data, error } = await db.from('roles').insert(role).select().single()
+  if (error) throw error
+  return data
+}
+
+export async function updateRole(
+  db: SupabaseClient<Database>,
+  id: number,
+  updates: RoleUpdate
+): Promise<RoleRow> {
+  const { data, error } = await db
+    .from('roles')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single()
+  if (error) throw error
+  return data
+}
+
+export async function deleteRole(
+  db: SupabaseClient<Database>,
+  id: number
+): Promise<void> {
+  const { error } = await db.from('roles').delete().eq('id', id)
+  if (error) throw error
+}
+
+/** Replace a role's full module permission grid in one call. */
+export async function setRolePermissions(
+  db: SupabaseClient<Database>,
+  roleId: number,
+  grid: Partial<Record<ModuleKey, AccessLevel | null>>
+): Promise<void> {
+  const { error: deleteError } = await db
+    .from('module_permissions')
+    .delete()
+    .eq('role_id', roleId)
+  if (deleteError) throw deleteError
+
+  const rows = Object.entries(grid)
+    .filter(([, level]) => level)
+    .map(([module, access_level]) => ({
+      role_id: roleId,
+      module: module as ModuleKey,
+      access_level: access_level as AccessLevel
+    }))
+
+  if (rows.length === 0) return
+
+  const { error: insertError } = await db
+    .from('module_permissions')
+    .insert(rows)
+  if (insertError) throw insertError
+}

--- a/frontend/repositories/user-roles.repo.ts
+++ b/frontend/repositories/user-roles.repo.ts
@@ -1,0 +1,87 @@
+import type { Database, Tables } from '@/types/database'
+import type { AccessLevel, ModuleAccessMap } from '@/types/domain/users'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type UserRoleRow = Tables<'user_roles'>
+
+export async function assignRole(
+  db: SupabaseClient<Database>,
+  userId: string,
+  roleId: number,
+  assignedBy: string | null
+): Promise<void> {
+  const { error } = await db
+    .from('user_roles')
+    .insert({ user_id: userId, role_id: roleId, assigned_by: assignedBy })
+  if (error && error.code !== '23505') throw error // ignore duplicate assignment
+}
+
+export async function unassignRole(
+  db: SupabaseClient<Database>,
+  userId: string,
+  roleId: number
+): Promise<void> {
+  const { error } = await db
+    .from('user_roles')
+    .delete()
+    .eq('user_id', userId)
+    .eq('role_id', roleId)
+  if (error) throw error
+}
+
+/** Replace a user's full set of role assignments in one call. */
+export async function setUserRoles(
+  db: SupabaseClient<Database>,
+  userId: string,
+  roleIds: number[],
+  assignedBy: string | null
+): Promise<void> {
+  const { error: deleteError } = await db
+    .from('user_roles')
+    .delete()
+    .eq('user_id', userId)
+  if (deleteError) throw deleteError
+
+  if (roleIds.length === 0) return
+
+  const rows = roleIds.map((roleId) => ({
+    user_id: userId,
+    role_id: roleId,
+    assigned_by: assignedBy
+  }))
+  const { error: insertError } = await db.from('user_roles').insert(rows)
+  if (insertError) throw insertError
+}
+
+/** Resolve the effective (most-permissive) per-module access for one user. */
+export async function findModuleAccessForUser(
+  db: SupabaseClient<Database>,
+  userId: string
+): Promise<ModuleAccessMap> {
+  const { data: assignments, error: assignmentsError } = await db
+    .from('user_roles')
+    .select('role_id')
+    .eq('user_id', userId)
+  if (assignmentsError) throw assignmentsError
+
+  const roleIds = (assignments ?? []).map((a) => a.role_id)
+  if (roleIds.length === 0) return {}
+
+  const { data: permissions, error: permissionsError } = await db
+    .from('module_permissions')
+    .select('module, access_level')
+    .in('role_id', roleIds)
+  if (permissionsError) throw permissionsError
+
+  const map: ModuleAccessMap = {}
+  for (const perm of permissions ?? []) {
+    const current = map[perm.module]
+    if (
+      !current ||
+      (current === 'view' && perm.access_level === ('manage' as AccessLevel))
+    ) {
+      map[perm.module] = perm.access_level
+    }
+  }
+  return map
+}

--- a/frontend/scripts/user-management-schema.sql
+++ b/frontend/scripts/user-management-schema.sql
@@ -1,0 +1,316 @@
+-- User Management: profiles, roles, per-module permissions
+-- Run this in the Supabase SQL Editor (supabase.com/dashboard -> SQL Editor).
+-- These tables are Supabase-native (not Django-managed).
+--
+-- Data model:
+--   profiles           <- one row per Supabase auth user (extends auth.users)
+--   roles              <- named roles, e.g. Administrator, Line Technician
+--   module_permissions <- per-role, per-module access level (view | manage)
+--   user_roles         <- many-to-many: which roles a profile holds
+--
+-- Access model:
+--   Every operational module (equipment, invoicing, training, parking,
+--   flight_operations, line_schedule, truck_sheets, fuel_farm) plus the
+--   'users' module itself is gated independently. A role grants either
+--   'view' (read-only) or 'manage' (full read/write) access per module;
+--   no row for a module means no access. A profile can hold multiple
+--   roles; access is the union (most-permissive) across all of them.
+--
+-- This improves on the house "any authenticated user can do anything"
+-- policy (see truck-sheets-schema.sql) by checking actual role grants
+-- via the has_module_access() helper below instead of auth.role().
+
+-- ============================================================
+-- 1. ROLES
+-- ============================================================
+CREATE TABLE IF NOT EXISTS roles (
+  id          BIGSERIAL PRIMARY KEY,
+  name        TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL DEFAULT '',
+  is_system   BOOLEAN NOT NULL DEFAULT FALSE, -- seeded roles; cannot be deleted
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ============================================================
+-- 2. MODULE PERMISSIONS: per-role access level per app module
+-- ============================================================
+CREATE TABLE IF NOT EXISTS module_permissions (
+  id            BIGSERIAL PRIMARY KEY,
+  role_id       BIGINT NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+  module        TEXT   NOT NULL CHECK (module IN (
+    'equipment', 'invoicing', 'training', 'parking',
+    'flight_operations', 'line_schedule', 'truck_sheets',
+    'fuel_farm', 'users'
+  )),
+  access_level  TEXT   NOT NULL CHECK (access_level IN ('view', 'manage')),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (role_id, module)
+);
+
+-- ============================================================
+-- 3. PROFILES: extends auth.users with app-facing directory data
+-- ============================================================
+CREATE TABLE IF NOT EXISTS profiles (
+  id            UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  email         TEXT NOT NULL,
+  first_name    TEXT NOT NULL DEFAULT '',
+  last_name     TEXT NOT NULL DEFAULT '',
+  phone_number  TEXT NOT NULL DEFAULT '',
+  employee_id   TEXT,
+  status        TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'disabled')),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by    UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  updated_by    UUID REFERENCES auth.users(id) ON DELETE SET NULL
+);
+
+-- ============================================================
+-- 4. USER ROLES: many-to-many, a profile can hold several roles
+-- ============================================================
+CREATE TABLE IF NOT EXISTS user_roles (
+  id          BIGSERIAL PRIMARY KEY,
+  user_id     UUID   NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  role_id     BIGINT NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+  assigned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  assigned_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  UNIQUE (user_id, role_id)
+);
+
+-- ============================================================
+-- 5. Indexes
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_module_permissions_role   ON module_permissions(role_id);
+CREATE INDEX IF NOT EXISTS idx_user_roles_user            ON user_roles(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_roles_role            ON user_roles(role_id);
+CREATE INDEX IF NOT EXISTS idx_profiles_status            ON profiles(status);
+CREATE INDEX IF NOT EXISTS idx_profiles_email             ON profiles(email);
+
+-- ============================================================
+-- 6. updated_at maintenance
+-- ============================================================
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_roles_updated_at ON roles;
+CREATE TRIGGER trg_roles_updated_at
+  BEFORE UPDATE ON roles
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_profiles_updated_at ON profiles;
+CREATE TRIGGER trg_profiles_updated_at
+  BEFORE UPDATE ON profiles
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- ============================================================
+-- 7. Auto-create a profile row whenever a Supabase auth user is
+--    created (self-registration via /register, or an admin invite
+--    via supabase.auth.admin.inviteUserByEmail).
+-- ============================================================
+CREATE OR REPLACE FUNCTION handle_new_auth_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.profiles (id, email, first_name, last_name)
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.email, ''),
+    COALESCE(NEW.raw_user_meta_data->>'first_name', ''),
+    COALESCE(NEW.raw_user_meta_data->>'last_name', '')
+  )
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION handle_new_auth_user();
+
+-- ============================================================
+-- 8. Permission helper: does the current user hold at least
+--    p_min_level access on p_module, via any of their roles?
+--    'manage' implies 'view'. SECURITY DEFINER so it can read
+--    user_roles/module_permissions regardless of the caller's
+--    own row-level access to those tables.
+-- ============================================================
+CREATE OR REPLACE FUNCTION has_module_access(p_module TEXT, p_min_level TEXT DEFAULT 'view')
+RETURNS BOOLEAN
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM user_roles ur
+    JOIN module_permissions mp ON mp.role_id = ur.role_id
+    WHERE ur.user_id = auth.uid()
+      AND mp.module = p_module
+      AND (
+        p_min_level = 'view'
+        OR mp.access_level = 'manage'
+      )
+  );
+$$;
+
+-- Convenience wrapper used throughout the RLS policies below.
+CREATE OR REPLACE FUNCTION can_manage_users()
+RETURNS BOOLEAN
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT has_module_access('users', 'manage');
+$$;
+
+-- ============================================================
+-- 9. RLS
+-- ============================================================
+ALTER TABLE roles               ENABLE ROW LEVEL SECURITY;
+ALTER TABLE module_permissions  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE profiles            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_roles          ENABLE ROW LEVEL SECURITY;
+
+-- Roles & module_permissions: any authenticated user may read them
+-- (the client needs this to resolve its own effective permissions);
+-- only users-module managers may write.
+CREATE POLICY "Authenticated users can view roles"
+  ON roles FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY "Users admins can manage roles"
+  ON roles FOR INSERT WITH CHECK (can_manage_users());
+CREATE POLICY "Users admins can update roles"
+  ON roles FOR UPDATE USING (can_manage_users());
+CREATE POLICY "Users admins can delete non-system roles"
+  ON roles FOR DELETE USING (can_manage_users() AND NOT is_system);
+
+CREATE POLICY "Authenticated users can view module permissions"
+  ON module_permissions FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY "Users admins can manage module permissions"
+  ON module_permissions FOR INSERT WITH CHECK (can_manage_users());
+CREATE POLICY "Users admins can update module permissions"
+  ON module_permissions FOR UPDATE USING (can_manage_users());
+CREATE POLICY "Users admins can delete module permissions"
+  ON module_permissions FOR DELETE USING (can_manage_users());
+
+-- Profiles: everyone can see the directory (needed for staff pickers
+-- across other modules, e.g. assigning a line tech); a user can always
+-- edit their own row; only users-module managers can edit others or
+-- delete accounts. Row inserts happen via the auth trigger (or the
+-- service-role invite route), never directly from a client.
+CREATE POLICY "Authenticated users can view profiles"
+  ON profiles FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY "Users can update their own profile"
+  ON profiles FOR UPDATE
+  USING (auth.uid() = id OR can_manage_users());
+
+CREATE POLICY "Users admins can delete profiles"
+  ON profiles FOR DELETE
+  USING (can_manage_users());
+
+-- User roles: a user can see their own role assignments (to resolve
+-- their own permissions); users-module managers can see and manage
+-- everyone's.
+CREATE POLICY "Users can view their own role assignments"
+  ON user_roles FOR SELECT
+  USING (auth.uid() = user_id OR can_manage_users());
+
+CREATE POLICY "Users admins can assign roles"
+  ON user_roles FOR INSERT WITH CHECK (can_manage_users());
+CREATE POLICY "Users admins can update role assignments"
+  ON user_roles FOR UPDATE USING (can_manage_users());
+CREATE POLICY "Users admins can remove role assignments"
+  ON user_roles FOR DELETE USING (can_manage_users());
+
+-- ============================================================
+-- 10. Seed default roles + a sensible starting permission matrix
+-- ============================================================
+INSERT INTO roles (name, description, is_system) VALUES
+  ('Administrator',   'Full access to every module, including user management.', TRUE),
+  ('Management',      'View across all operations, manage staffing-facing modules.', TRUE),
+  ('Office Staff',    'Manage front-office modules: invoicing, parking, flight ops.', TRUE),
+  ('Line Technician',  'Line-facing modules only: equipment, fuel farm, truck sheets, training.', TRUE)
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO module_permissions (role_id, module, access_level)
+SELECT r.id, m.module, 'manage'
+FROM roles r
+CROSS JOIN (VALUES
+  ('equipment'), ('invoicing'), ('training'), ('parking'),
+  ('flight_operations'), ('line_schedule'), ('truck_sheets'),
+  ('fuel_farm'), ('users')
+) AS m(module)
+WHERE r.name = 'Administrator'
+ON CONFLICT (role_id, module) DO NOTHING;
+
+INSERT INTO module_permissions (role_id, module, access_level)
+SELECT r.id, m.module, m.level
+FROM roles r
+CROSS JOIN (VALUES
+  ('equipment', 'view'), ('invoicing', 'view'), ('training', 'view'),
+  ('parking', 'view'), ('flight_operations', 'view'),
+  ('line_schedule', 'manage'), ('truck_sheets', 'view'),
+  ('fuel_farm', 'view'), ('users', 'view')
+) AS m(module, level)
+WHERE r.name = 'Management'
+ON CONFLICT (role_id, module) DO NOTHING;
+
+INSERT INTO module_permissions (role_id, module, access_level)
+SELECT r.id, m.module, m.level
+FROM roles r
+CROSS JOIN (VALUES
+  ('invoicing', 'manage'), ('parking', 'manage'),
+  ('flight_operations', 'manage'), ('line_schedule', 'view'),
+  ('equipment', 'view')
+) AS m(module, level)
+WHERE r.name = 'Office Staff'
+ON CONFLICT (role_id, module) DO NOTHING;
+
+INSERT INTO module_permissions (role_id, module, access_level)
+SELECT r.id, m.module, m.level
+FROM roles r
+CROSS JOIN (VALUES
+  ('equipment', 'manage'), ('fuel_farm', 'manage'),
+  ('truck_sheets', 'manage'), ('training', 'view'),
+  ('line_schedule', 'view')
+) AS m(module, level)
+WHERE r.name = 'Line Technician'
+ON CONFLICT (role_id, module) DO NOTHING;
+
+-- ============================================================
+-- 11. Backfill: create a profile for any auth user that predates
+--     this migration (the trigger only fires on new signups).
+-- ============================================================
+INSERT INTO profiles (id, email)
+SELECT u.id, u.email
+FROM auth.users u
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================
+-- 12. Bootstrap: grant the Administrator role to your own account
+--     so you're not locked out of /users after running this script.
+--     Replace the email below and run manually.
+-- ============================================================
+-- INSERT INTO user_roles (user_id, role_id, assigned_by)
+-- SELECT p.id, r.id, p.id
+-- FROM profiles p, roles r
+-- WHERE p.email = 'you@example.com' AND r.name = 'Administrator'
+-- ON CONFLICT (user_id, role_id) DO NOTHING;

--- a/frontend/services/user-management.service.ts
+++ b/frontend/services/user-management.service.ts
@@ -1,0 +1,68 @@
+import { updateProfile } from '@/repositories/profiles.repo'
+import { setUserRoles } from '@/repositories/user-roles.repo'
+import type { Database } from '@/types/database'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export interface InviteUserInput {
+  email: string
+  firstName: string
+  lastName: string
+  phoneNumber: string
+  employeeId: string
+  roleIds: number[]
+}
+
+export async function inviteUser(
+  input: InviteUserInput
+): Promise<{ id: string }> {
+  const res = await fetch('/api/users/invite', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input)
+  })
+  const body = await res.json()
+  if (!res.ok) throw new Error(body.error ?? 'Failed to invite user')
+  return body
+}
+
+export async function deleteUser(id: string): Promise<void> {
+  const res = await fetch(`/api/users/${id}`, { method: 'DELETE' })
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(body.error ?? 'Failed to delete user')
+  }
+}
+
+export interface UpdateUserInput {
+  firstName: string
+  lastName: string
+  phoneNumber: string
+  employeeId: string
+  roleIds: number[]
+}
+
+/** Update a user's profile fields and replace their role assignments in one call. */
+export async function updateUserWithRoles(
+  db: SupabaseClient<Database>,
+  userId: string,
+  input: UpdateUserInput,
+  updatedBy: string | null
+): Promise<void> {
+  await updateProfile(db, userId, {
+    first_name: input.firstName,
+    last_name: input.lastName,
+    phone_number: input.phoneNumber,
+    employee_id: input.employeeId || null,
+    updated_by: updatedBy
+  })
+  await setUserRoles(db, userId, input.roleIds, updatedBy)
+}
+
+export async function setUserActiveStatus(
+  db: SupabaseClient<Database>,
+  userId: string,
+  status: 'active' | 'disabled',
+  updatedBy: string | null
+): Promise<void> {
+  await updateProfile(db, userId, { status, updated_by: updatedBy })
+}

--- a/frontend/types/database.ts
+++ b/frontend/types/database.ts
@@ -853,6 +853,124 @@ export type Database = {
           },
         ]
       }
+      profiles: {
+        Row: {
+          id: string
+          email: string
+          first_name: string
+          last_name: string
+          phone_number: string
+          employee_id: string | null
+          status: 'active' | 'disabled'
+          created_at: string
+          updated_at: string
+          created_by: string | null
+          updated_by: string | null
+        }
+        Insert: {
+          id: string
+          email: string
+          first_name?: string
+          last_name?: string
+          phone_number?: string
+          employee_id?: string | null
+          status?: 'active' | 'disabled'
+          created_by?: string | null
+          updated_by?: string | null
+        }
+        Update: Partial<Database['public']['Tables']['profiles']['Insert']>
+        Relationships: []
+      }
+      roles: {
+        Row: {
+          id: number
+          name: string
+          description: string
+          is_system: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: number
+          name: string
+          description?: string
+          is_system?: boolean
+        }
+        Update: Partial<Database['public']['Tables']['roles']['Insert']>
+        Relationships: []
+      }
+      module_permissions: {
+        Row: {
+          id: number
+          role_id: number
+          module:
+            | 'equipment'
+            | 'invoicing'
+            | 'training'
+            | 'parking'
+            | 'flight_operations'
+            | 'line_schedule'
+            | 'truck_sheets'
+            | 'fuel_farm'
+            | 'users'
+          access_level: 'view' | 'manage'
+          created_at: string
+        }
+        Insert: {
+          id?: number
+          role_id: number
+          module:
+            | 'equipment'
+            | 'invoicing'
+            | 'training'
+            | 'parking'
+            | 'flight_operations'
+            | 'line_schedule'
+            | 'truck_sheets'
+            | 'fuel_farm'
+            | 'users'
+          access_level: 'view' | 'manage'
+        }
+        Update: Partial<Database['public']['Tables']['module_permissions']['Insert']>
+        Relationships: [
+          {
+            foreignKeyName: 'module_permissions_role_id_fkey'
+            columns: ['role_id']
+            referencedRelation: 'roles'
+            referencedColumns: ['id']
+          }
+        ]
+      }
+      user_roles: {
+        Row: {
+          id: number
+          user_id: string
+          role_id: number
+          assigned_at: string
+          assigned_by: string | null
+        }
+        Insert: {
+          id?: number
+          user_id: string
+          role_id: number
+          assigned_by?: string | null
+        }
+        Update: Partial<Database['public']['Tables']['user_roles']['Insert']>
+        Relationships: [
+          {
+            foreignKeyName: 'user_roles_user_id_fkey'
+            columns: ['user_id']
+            referencedRelation: 'profiles'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'user_roles_role_id_fkey'
+            columns: ['role_id']
+            referencedRelation: 'roles'
+            referencedColumns: ['id']
+          }
+        ]
+      }
     }
     Views: Record<string, never>
     Functions: {

--- a/frontend/types/domain/users.ts
+++ b/frontend/types/domain/users.ts
@@ -1,0 +1,43 @@
+import type { Tables } from '@/types/database'
+
+export type ProfileRow = Tables<'profiles'>
+export type RoleRow = Tables<'roles'>
+export type ModulePermissionRow = Tables<'module_permissions'>
+export type UserRoleRow = Tables<'user_roles'>
+
+export type ModuleKey = ModulePermissionRow['module']
+export type AccessLevel = ModulePermissionRow['access_level']
+
+export const MODULES: { key: ModuleKey; label: string }[] = [
+  { key: 'equipment', label: 'Equipment' },
+  { key: 'invoicing', label: 'Invoicing' },
+  { key: 'training', label: 'Training' },
+  { key: 'parking', label: 'Parking' },
+  { key: 'flight_operations', label: 'Flight Operations' },
+  { key: 'line_schedule', label: 'Line Schedule' },
+  { key: 'truck_sheets', label: 'Truck Sheets' },
+  { key: 'fuel_farm', label: 'Fuel Farm' },
+  { key: 'users', label: 'User Management' }
+]
+
+export interface RoleWithPermissions extends RoleRow {
+  permissions: ModulePermissionRow[]
+}
+
+export interface ProfileWithRoles extends ProfileRow {
+  roles: RoleRow[]
+}
+
+/** module -> highest access level the current user holds across all of their roles */
+export type ModuleAccessMap = Partial<Record<ModuleKey, AccessLevel>>
+
+export function accessAtLeast(
+  map: ModuleAccessMap,
+  module: ModuleKey,
+  min: AccessLevel
+): boolean {
+  const level = map[module]
+  if (!level) return false
+  if (min === 'view') return true
+  return level === 'manage'
+}


### PR DESCRIPTION
## Summary
- Scoped port of PR #19 (`worktree-agent-a08525d7d4abb2790`), which was rooted 4+ features behind current master (pre truck-sheets/training-rebuild/equipment-update/fuel-orders-module) — a direct merge would have reverted a large amount of already-merged work.
- Cherry-picked the module's single commit onto current master, resolving conflicts in `navigation.tsx` (kept both the "Truck Sheets" nav item added since this branch forked and the new "Users" item + profile dropdown) and `types/database.ts` (interleaved the new `profiles`/`roles`/`module_permissions`/`user_roles` table types alongside `truck_sheets`/`truck_meter_readings`, which were added to the same file independently).
- `frontend/scripts/user-management-schema.sql` — raw SQL, Supabase-native, already applied to the live DB in a prior session (tables confirmed present).

## Follow-up needed (not a merge blocker)
`user_roles` has 0 rows live — nobody currently holds the Administrator role, so `/users` is effectively locked out for everyone until someone runs the commented-out bootstrap insert at the bottom of `user-management-schema.sql` with a real account email. The only `profiles` rows in the live DB are seed/placeholder accounts (`*.example.com`, `admin@fbo.local`, `user@fbo.local`) — none obviously maps to Ted's real account, so this wasn't guessed at.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `next build` passes (`/users`, `/users/roles` routes present)