### PR TITLE
feat: add edit-concurrency layer with presence and conflict detection — scoped port of #20

### DIFF
--- a/docs/edit-concurrency.md
+++ b/docs/edit-concurrency.md
@@ -1,0 +1,112 @@
+# Edit Concurrency
+
+Multiple staff can open the same record's edit `Sheet`/`Dialog` at the same time. Without any
+concurrency awareness, whoever saves last silently overwrites the other person's changes. This
+is optimistic concurrency with live presence — not a hard lock. A hard lock is the wrong tool
+here: browser tabs crash and laptops close mid-edit, and a stuck lock would strand the record
+for everyone.
+
+Two independent mechanisms, both provided by a single hook:
+
+## 1. Presence — "Ted is also editing this"
+
+While a record's edit form is open, we join a Supabase Realtime Presence channel scoped to
+`edit-session:{table}:{id}`. Every other browser tab with that same record open sees a banner
+listing who else is in there. This is purely informational — it doesn't block anything.
+
+## 2. Save-time conflict detection (atomic compare-and-swap)
+
+When the form loads, it captures the record's current `modified_at`. On save, the write itself
+is the check — there is no separate "read timestamp, then write" round trip (that would leave a
+race window between the check and the write). Instead:
+
+```sql
+UPDATE fuel_tank
+SET ..., -- no modified_at here; a DB trigger sets it (see below)
+WHERE tank_id = :id AND modified_at = :expected_modified_at
+RETURNING *;
+```
+
+If zero rows come back, someone else saved a change since the form loaded — atomically detected,
+no separate check step. The caller gets a `ConcurrencyConflictError` and shows a dialog with two
+choices: **"Reload their changes"** (re-fetch the record and discard local edits) or
+**"Overwrite anyway"** (retry the write with no guard, accepting you're clobbering their change).
+The choice is logged via `console.info` — there's no `notes`/audit field on these tables to write
+it into, but it isn't dropped silently either.
+
+### Why the live-change banner exists too
+
+The compare-and-swap above is only checked when *you* try to save. To make the experience
+proactive instead of purely reactive, the hook also subscribes to Supabase Realtime
+`postgres_changes` UPDATE events for the specific record (`id=eq.<id>`, or the table's actual PK
+column). If another save lands while your Sheet is still open, you see the same
+reload/keep-editing choice immediately — you don't have to hit save to find out. The
+compare-and-swap on save remains the final safety net regardless (it covers the case where the
+subscription drops, is delayed, or never connects).
+
+### The `modified_at` trigger requirement
+
+The compare-and-swap only works if `modified_at` is **guaranteed** to change on every write. Both
+`fuel_tank` and `fuel_transaction` originally carried a Django-managed `modified_at` column
+(`auto_now=True`), but `auto_now` is enforced by the Django ORM at `save()` time. It does nothing
+for writes that skip the ORM — and the frontend writes both tables directly via Supabase PostgREST
+(`frontend/repositories/tanks.repo.ts`, `transactions.repo.ts`), never touching Django. (This
+project has since fully decoupled from Django — see the no-Django convention for schema changes
+below.)
+
+Before this feature, `modified_at` was **not** being updated by frontend writes at all.
+`frontend/scripts/modified-at-triggers.sql` adds a `BEFORE UPDATE` Postgres trigger
+(`set_modified_at()`) on `fuel_tank` and `fuel_transaction` so `modified_at` updates at the
+database level regardless of write path. It also registers both tables with the
+`supabase_realtime` publication so `postgres_changes` events actually fire for them. Run it
+directly against the live Supabase DB (`psql` or the Supabase SQL Editor) — like every other
+schema change in this project, it's a plain SQL script, not a Django migration.
+
+**If you adopt this pattern for another table, check first whether that table has a comparable
+trigger.** As of this writing, no other table has one — `modified_at`/`created_at` fields
+elsewhere (equipment, training, invoicing, user management, etc.) have the same silent-gap risk if
+they're written to directly via Supabase without a trigger. Add a trigger for your table using the
+existing `set_modified_at()` function (it's generic — a two-line
+`CREATE TRIGGER ... EXECUTE FUNCTION set_modified_at();` in a new `frontend/scripts/*.sql` file,
+not a new pattern), and add the table to `supabase_realtime` the same way, before wiring up the
+hook. Don't assume a trigger exists just because one table has it.
+
+## Using the hook
+
+```tsx
+import { useRecordEditSession } from '@/hooks/use-record-edit-session'
+import { EditSessionStatus } from '@/components/shared/edit-session-status'
+
+const editSession = useRecordEditSession({
+  table: 'fuel_tank',        // must have a modified_at trigger — see above
+  idColumn: 'tank_id',       // defaults to 'id'
+  recordId: tank?.tank_id ?? null,
+  modifiedAt: tank?.modified_at ?? null,
+  enabled: open && !!tank,   // typically the Sheet/Dialog's open state, gated on "editing"
+  onReload: (freshRow) => setFormData(mapRowToFormData(freshRow))
+})
+
+// In the form's submit handler:
+const outcome = await editSession.save((expectedModifiedAt) =>
+  onSubmit(formData, expectedModifiedAt)
+)
+if (outcome.status === 'conflict') return // dialog is shown by <EditSessionStatus>
+
+// In the JSX, near the top of the Sheet/Dialog content:
+<EditSessionStatus editSession={editSession} onOverwriteComplete={() => onOpenChange(false)} />
+```
+
+The repository's update function needs to accept an optional `expectedModifiedAt` and use it as
+an `.eq('modified_at', expectedModifiedAt)` guard, throwing `ConcurrencyConflictError` (from
+`@/lib/concurrency`) when the write matches zero rows. See `updateTank` in
+`frontend/repositories/tanks.repo.ts` and `updateTransaction` in
+`frontend/repositories/transactions.repo.ts` for the reference implementation.
+
+## Reference implementations
+
+- `frontend/components/fuel-farm/tank-form-dialog.tsx` / `frontend/app/fuel-farm/page.tsx`
+- `frontend/components/fuel-dispatch/transaction-form-dialog.tsx` / `frontend/app/dispatch/page.tsx`
+
+This pass intentionally only wires up these two modules. Roll the pattern out to other
+`Sheet`/`Dialog` edit forms incrementally, checking the `modified_at` trigger situation for each
+table first.

--- a/frontend/app/dispatch/page.tsx
+++ b/frontend/app/dispatch/page.tsx
@@ -5,6 +5,7 @@ import { useTheme } from '@/components/navigation-wrapper'
 import type { TransactionInsert, TransactionWithRelations } from '@/repositories/transactions.repo'
 import { useTransactions } from '@/hooks/use-transactions'
 import { useFuelers } from '@/hooks/use-fuelers'
+import { ConcurrencyConflictError } from '@/lib/concurrency'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
@@ -59,15 +60,18 @@ export default function FuelDispatchPage() {
   }
 
   const handleUpdateTransaction = async (
-    data: TransactionInsert
+    data: TransactionInsert,
+    expectedModifiedAt?: string
   ) => {
     if (!editingTransaction) return
     try {
-      await updateTransaction(editingTransaction.id, data)
+      await updateTransaction(editingTransaction.id, data, expectedModifiedAt)
       setSuccessMessage('Transaction updated successfully')
       setTimeout(() => setSuccessMessage(''), 3000)
       setEditingTransaction(null)
     } catch (err) {
+      // A concurrency conflict is handled by the form's edit-session dialog, not a toast.
+      if (err instanceof ConcurrencyConflictError) throw err
       setErrorMessage('Failed to update transaction')
       setTimeout(() => setErrorMessage(''), 3000)
       throw err

--- a/frontend/app/fuel-farm/page.tsx
+++ b/frontend/app/fuel-farm/page.tsx
@@ -8,6 +8,7 @@ import type { TankInsert, TankWithLatestReading } from '@/repositories/tanks.rep
 import { createTankReading } from '@/repositories/tank-readings.repo'
 import { inchesToGallons } from '@/lib/gallons-tables'
 import { createClient } from '@/lib/supabase/client'
+import { ConcurrencyConflictError } from '@/lib/concurrency'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
@@ -78,21 +79,27 @@ export default function FuelFarmPage() {
     setDialogOpen(true)
   }
 
-  const handleUpdateTank = async (data: TankInsert) => {
+  const handleUpdateTank = async (data: TankInsert, expectedModifiedAt?: string) => {
     if (!editingTank) return
     try {
-      await updateTank(editingTank.tank_id, {
-        tank_name: data.tank_name as string,
-        fuel_type: data.fuel_type as 'jet_a' | 'avgas',
-        capacity_gallons: data.capacity_gallons,
-        min_level_inches: data.min_level_inches,
-        max_level_inches: data.max_level_inches,
-        usable_min_inches: data.usable_min_inches,
-        usable_max_inches: data.usable_max_inches
-      })
+      await updateTank(
+        editingTank.tank_id,
+        {
+          tank_name: data.tank_name as string,
+          fuel_type: data.fuel_type as 'jet_a' | 'avgas',
+          capacity_gallons: data.capacity_gallons,
+          min_level_inches: data.min_level_inches,
+          max_level_inches: data.max_level_inches,
+          usable_min_inches: data.usable_min_inches,
+          usable_max_inches: data.usable_max_inches
+        },
+        expectedModifiedAt
+      )
       showSuccess('Tank updated successfully')
       setEditingTank(null)
     } catch (err) {
+      // A concurrency conflict is handled by the form's edit-session dialog, not a toast.
+      if (err instanceof ConcurrencyConflictError) throw err
       showError('Failed to update tank')
       throw err
     }

--- a/frontend/components/fuel-dispatch/transaction-form-dialog.tsx
+++ b/frontend/components/fuel-dispatch/transaction-form-dialog.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { EditSessionStatus } from '@/components/shared/edit-session-status'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -25,7 +26,12 @@ import {
 import { createClient } from '@/lib/supabase/client'
 import { useEquipment } from '@/hooks/use-equipment'
 import { useFlights } from '@/hooks/use-flights'
-import type { TransactionInsert, TransactionWithRelations } from '@/repositories/transactions.repo'
+import { useRecordEditSession } from '@/hooks/use-record-edit-session'
+import type {
+  TransactionInsert,
+  TransactionRow,
+  TransactionWithRelations
+} from '@/repositories/transactions.repo'
 import { format } from 'date-fns'
 import { useEffect, useMemo, useState } from 'react'
 
@@ -46,7 +52,10 @@ interface TransactionFormDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   transaction?: TransactionWithRelations | null
-  onSubmit: (data: TransactionInsert) => Promise<void>
+  onSubmit: (
+    data: TransactionInsert,
+    expectedModifiedAt?: string
+  ) => Promise<void>
   defaultFlightId?: number | null
   defaultTailNumber?: string
 }
@@ -126,6 +135,25 @@ export function TransactionFormDialog({
       })
   }, [open, transaction, defaultFlightId, defaultTailNumber, db])
 
+  const editSession = useRecordEditSession<TransactionRow>({
+    table: 'fuel_transaction',
+    recordId: transaction?.id ?? null,
+    modifiedAt: transaction?.modified_at ?? null,
+    enabled: open && !!transaction,
+    onReload: (freshRow) => {
+      setForm({
+        ticket_number: freshRow.ticket_number,
+        flight_id: freshRow.flight_id,
+        tail_number: freshRow.tail_number ?? '',
+        fuel_type: (freshRow.fuel_type as FuelType) ?? '',
+        fuel_truck_id: freshRow.fuel_truck_id,
+        fuel_order_text: freshRow.fuel_order_text ?? '',
+        quantity_gallons: freshRow.quantity_gallons ?? '',
+        quantity_lbs: freshRow.quantity_lbs ?? ''
+      })
+    }
+  })
+
   const density =
     form.quantity_gallons && form.quantity_lbs
       ? (Number(form.quantity_lbs) / Number(form.quantity_gallons)).toFixed(4)
@@ -154,7 +182,14 @@ export function TransactionFormDialog({
         source: transaction?.source ?? 'manual',
         charge_flags: undefined
       }
-      await onSubmit(payload)
+      if (transaction) {
+        const outcome = await editSession.save((expectedModifiedAt) =>
+          onSubmit(payload, expectedModifiedAt)
+        )
+        if (outcome.status === 'conflict') return
+      } else {
+        await onSubmit(payload)
+      }
       onOpenChange(false)
     } catch (err) {
       console.error('Failed to save transaction:', err)
@@ -182,6 +217,15 @@ export function TransactionFormDialog({
               : 'Create a new fuel order for line staff.'}
           </SheetDescription>
         </SheetHeader>
+
+        {transaction && (
+          <div className="px-4 pt-4">
+            <EditSessionStatus
+              editSession={editSession}
+              onOverwriteComplete={() => onOpenChange(false)}
+            />
+          </div>
+        )}
 
         <form onSubmit={handleSubmit} className="flex flex-1 flex-col overflow-hidden">
           <div className="flex-1 space-y-4 overflow-y-auto p-4">

--- a/frontend/components/fuel-farm/tank-form-dialog.tsx
+++ b/frontend/components/fuel-farm/tank-form-dialog.tsx
@@ -1,7 +1,9 @@
 'use client'
 
+import { EditSessionStatus } from '@/components/shared/edit-session-status'
 import type {
   TankInsert,
+  TankRow,
   TankWithLatestReading
 } from '@/repositories/tanks.repo'
 import { Button } from '@/components/ui/button'
@@ -22,13 +24,14 @@ import {
   SheetHeader,
   SheetTitle
 } from '@/components/ui/sheet'
+import { useRecordEditSession } from '@/hooks/use-record-edit-session'
 import { useEffect, useState } from 'react'
 
 interface TankFormDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   tank?: TankWithLatestReading | null
-  onSubmit: (data: TankInsert) => Promise<void>
+  onSubmit: (data: TankInsert, expectedModifiedAt?: string) => Promise<void>
 }
 
 export function TankFormDialog({
@@ -75,11 +78,38 @@ export function TankFormDialog({
     }
   }, [tank, open])
 
+  const editSession = useRecordEditSession<TankRow>({
+    table: 'fuel_tank',
+    idColumn: 'tank_id',
+    recordId: tank?.tank_id ?? null,
+    modifiedAt: tank?.modified_at ?? null,
+    enabled: open && !!tank,
+    onReload: (freshRow) => {
+      setFormData({
+        tank_id: freshRow.tank_id,
+        tank_name: freshRow.tank_name,
+        fuel_type: freshRow.fuel_type,
+        capacity_gallons: freshRow.capacity_gallons,
+        min_level_inches: freshRow.min_level_inches,
+        max_level_inches: freshRow.max_level_inches,
+        usable_min_inches: freshRow.usable_min_inches,
+        usable_max_inches: freshRow.usable_max_inches
+      })
+    }
+  })
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setLoading(true)
     try {
-      await onSubmit(formData)
+      if (tank) {
+        const outcome = await editSession.save((expectedModifiedAt) =>
+          onSubmit(formData, expectedModifiedAt)
+        )
+        if (outcome.status === 'conflict') return
+      } else {
+        await onSubmit(formData)
+      }
       onOpenChange(false)
     } catch (error) {
       console.error('Failed to save tank:', error)
@@ -102,6 +132,14 @@ export function TankFormDialog({
               : 'Add a new fuel tank to the farm.'}
           </SheetDescription>
         </SheetHeader>
+        {tank && (
+          <div className="px-4 pt-4">
+            <EditSessionStatus
+              editSession={editSession}
+              onOverwriteComplete={() => onOpenChange(false)}
+            />
+          </div>
+        )}
         <form
           onSubmit={handleSubmit}
           className="flex flex-1 flex-col overflow-hidden"

--- a/frontend/components/shared/edit-session-status.tsx
+++ b/frontend/components/shared/edit-session-status.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import type { UseRecordEditSessionResult } from '@/hooks/use-record-edit-session'
+import { RefreshCw, Users } from 'lucide-react'
+
+function formatPeerNames(names: string[]): string {
+  if (names.length === 1) return names[0]
+  if (names.length === 2) return `${names[0]} and ${names[1]}`
+  return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`
+}
+
+export interface EditSessionStatusProps {
+  // biome-ignore lint/suspicious/noExplicitAny: shared across differently-shaped record rows
+  editSession: UseRecordEditSessionResult<any>
+  /** Called after "Overwrite anyway" completes a save, e.g. to close the Sheet. */
+  onOverwriteComplete?: () => void
+}
+
+/**
+ * Sheet-consistent presence banner + live-change banner + save-conflict dialog for a
+ * record edit session. See docs/edit-concurrency.md for the pattern this backs.
+ */
+export function EditSessionStatus({
+  editSession,
+  onOverwriteComplete
+}: EditSessionStatusProps) {
+  const {
+    peers,
+    remoteChangeDetected,
+    dismissRemoteChange,
+    conflict,
+    resolveConflict,
+    reloading
+  } = editSession
+
+  return (
+    <>
+      {peers.length > 0 && (
+        <Alert>
+          <Users />
+          <AlertTitle>
+            {formatPeerNames(peers.map((p) => p.name))}{' '}
+            {peers.length === 1 ? 'is' : 'are'} also editing this
+          </AlertTitle>
+          <AlertDescription>
+            Changes may conflict if you both save. Coordinate before submitting.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {remoteChangeDetected && !conflict && (
+        <Alert variant="destructive">
+          <RefreshCw />
+          <AlertTitle>This record was just changed by someone else</AlertTitle>
+          <AlertDescription>
+            <p>
+              Reload to see their changes, or keep editing — you&apos;ll be
+              asked again on save.
+            </p>
+            <div className="mt-2 flex gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={reloading}
+                onClick={() => resolveConflict('reload')}
+              >
+                {reloading ? 'Reloading...' : 'Reload'}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={dismissRemoteChange}
+              >
+                Keep editing
+              </Button>
+            </div>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <AlertDialog open={conflict}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Someone else saved changes to this record
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Your changes are based on an older version. You can reload their
+              changes (discarding your edits) or overwrite with your version
+              anyway.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={reloading}
+              onClick={async () => {
+                await resolveConflict('overwrite')
+                onOverwriteComplete?.()
+              }}
+            >
+              Overwrite anyway
+            </Button>
+            <Button
+              type="button"
+              disabled={reloading}
+              onClick={() => resolveConflict('reload')}
+            >
+              {reloading ? 'Reloading...' : 'Reload their changes'}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/frontend/hooks/use-record-edit-session.ts
+++ b/frontend/hooks/use-record-edit-session.ts
@@ -1,0 +1,312 @@
+'use client'
+
+import { useSession } from '@/hooks/use-session'
+import { ConcurrencyConflictError } from '@/lib/concurrency'
+import { createClient } from '@/lib/supabase/client'
+import type { RealtimeChannel } from '@supabase/supabase-js'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+export interface EditPeer {
+  /** Stable identity used to de-dupe/exclude ourselves. Not necessarily the DB user id. */
+  key: string
+  name: string
+}
+
+export type SaveOutcome<T> =
+  | { status: 'saved'; data: T }
+  | { status: 'conflict' }
+
+export type ConflictChoice = 'reload' | 'overwrite'
+
+export interface UseRecordEditSessionOptions<
+  TRow extends Record<string, unknown>
+> {
+  /** Table name, used for the realtime channel and (on reload) a direct refetch. */
+  table: string
+  /** Primary key column name. Defaults to 'id'. */
+  idColumn?: string
+  /** Column that changes on every write. Defaults to 'modified_at' (this codebase's convention). */
+  modifiedAtColumn?: string
+  /** The record's id. Pass null/undefined while creating a new record (no session is started). */
+  recordId: string | number | null | undefined
+  /** The value of `modifiedAtColumn` as loaded into the form. Pass null/undefined for new records. */
+  modifiedAt: string | null | undefined
+  /** Only track presence / subscribe while the Sheet/dialog is actually open for this record. */
+  enabled: boolean
+  /**
+   * Called with the freshly-fetched row after the user chooses "reload" (either from the
+   * live-change banner or the save-time conflict dialog). Use it to repopulate form state.
+   */
+  onReload?: (freshRow: TRow) => void
+}
+
+export interface UseRecordEditSessionResult<
+  TRow extends Record<string, unknown>
+> {
+  /** Other users currently editing this same record (presence). */
+  peers: EditPeer[]
+  /** A postgres_changes UPDATE landed for this record while the Sheet was open. */
+  remoteChangeDetected: boolean
+  /** Dismiss the live-change banner and keep editing (save will still guard via compare-and-swap). */
+  dismissRemoteChange: () => void
+  /** A save-time compare-and-swap came back with zero rows — someone saved in between. */
+  conflict: boolean
+  /**
+   * Wrap a save call. `saveFn` receives the expected `modifiedAt` to use as the
+   * compare-and-swap guard (undefined means "write unconditionally"). If the
+   * underlying write throws ConcurrencyConflictError, this resolves to
+   * `{ status: 'conflict' }` and flips `conflict` to true instead of rethrowing.
+   */
+  save: <T>(
+    saveFn: (expectedModifiedAt?: string) => Promise<T>
+  ) => Promise<SaveOutcome<T>>
+  /** Resolve an active conflict (from either the banner or the dialog). */
+  resolveConflict: (choice: ConflictChoice) => Promise<void>
+  /** True while a "reload" fetch is in flight. */
+  reloading: boolean
+}
+
+interface PresencePayload {
+  name: string
+  online_at: string
+}
+
+function getDisplayName(
+  session: ReturnType<typeof useSession>['data']
+): string {
+  const user = session?.user
+  if (!user) return 'Someone'
+  const metadata = user.user_metadata as Record<string, unknown> | undefined
+  const firstName =
+    typeof metadata?.first_name === 'string' ? metadata.first_name : ''
+  const lastName =
+    typeof metadata?.last_name === 'string' ? metadata.last_name : ''
+  const fullName = `${firstName} ${lastName}`.trim()
+  if (fullName) return fullName
+  return user.email ?? 'Someone'
+}
+
+export function useRecordEditSession<TRow extends Record<string, unknown>>(
+  options: UseRecordEditSessionOptions<TRow>
+): UseRecordEditSessionResult<TRow> {
+  const { table, recordId, modifiedAt, enabled, onReload } = options
+  const idColumn = options.idColumn ?? 'id'
+  const modifiedAtColumn = options.modifiedAtColumn ?? 'modified_at'
+
+  const db = useMemo(() => createClient(), [])
+  const { data: session } = useSession()
+  const displayName = getDisplayName(session)
+
+  // Stable per-mount identity so we can exclude ourselves from the peer list.
+  const selfKeyRef = useRef<string>(
+    session?.user?.id ?? Math.random().toString(36).slice(2)
+  )
+
+  const [peers, setPeers] = useState<EditPeer[]>([])
+  const [remoteChangeDetected, setRemoteChangeDetected] = useState(false)
+  const [conflict, setConflict] = useState(false)
+  const [reloading, setReloading] = useState(false)
+
+  const baselineRef = useRef<string | null>(modifiedAt ?? null)
+  const pendingSaveRef = useRef<
+    ((expectedModifiedAt?: string) => Promise<unknown>) | null
+  >(null)
+  const channelRef = useRef<RealtimeChannel | null>(null)
+
+  // Reset baseline whenever the record we're pointed at (or its loaded modifiedAt) changes.
+  // recordId is intentionally included even though unread: switching to a different
+  // record must reset state even in the (astronomically unlikely) case its modifiedAt
+  // string happens to match the previous one.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: recordId included intentionally, see above
+  useEffect(() => {
+    baselineRef.current = modifiedAt ?? null
+    setConflict(false)
+    setRemoteChangeDetected(false)
+  }, [recordId, modifiedAt])
+
+  useEffect(() => {
+    if (!enabled || recordId === null || recordId === undefined) {
+      setPeers([])
+      return
+    }
+
+    let cancelled = false
+    const channelName = `edit-session:${table}:${recordId}`
+    let channel: RealtimeChannel
+
+    try {
+      channel = db.channel(channelName, {
+        config: { presence: { key: selfKeyRef.current } }
+      })
+    } catch (err) {
+      // Presence/realtime is a nice-to-have — never let it break the edit form.
+      console.warn(
+        `[use-record-edit-session] failed to create channel ${channelName}`,
+        err
+      )
+      return
+    }
+
+    channel
+      .on('presence', { event: 'sync' }, () => {
+        try {
+          const state = channel.presenceState<PresencePayload>()
+          const others: EditPeer[] = []
+          for (const key of Object.keys(state)) {
+            if (key === selfKeyRef.current) continue
+            const entries = state[key]
+            const latest = entries[entries.length - 1]
+            if (latest) others.push({ key, name: latest.name })
+          }
+          if (!cancelled) setPeers(others)
+        } catch (err) {
+          console.warn(
+            '[use-record-edit-session] failed to read presence state',
+            err
+          )
+        }
+      })
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table,
+          filter: `${idColumn}=eq.${recordId}`
+        },
+        (payload: { new?: Record<string, unknown> }) => {
+          const newModifiedAt = payload.new?.[modifiedAtColumn]
+          if (
+            typeof newModifiedAt === 'string' &&
+            newModifiedAt !== baselineRef.current &&
+            !cancelled
+          ) {
+            setRemoteChangeDetected(true)
+          }
+        }
+      )
+      .subscribe(async (status) => {
+        if (status === 'SUBSCRIBED') {
+          try {
+            await channel.track({
+              name: displayName,
+              online_at: new Date().toISOString()
+            } satisfies PresencePayload)
+          } catch (err) {
+            console.warn(
+              '[use-record-edit-session] failed to track presence',
+              err
+            )
+          }
+        } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+          console.warn(
+            `[use-record-edit-session] realtime channel ${channelName} status: ${status}`
+          )
+        }
+      })
+
+    channelRef.current = channel
+
+    return () => {
+      cancelled = true
+      channel.untrack().catch(() => undefined)
+      db.removeChannel(channel)
+      if (channelRef.current === channel) channelRef.current = null
+      setPeers([])
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, recordId, table, idColumn, modifiedAtColumn, db, displayName])
+
+  const dismissRemoteChange = useCallback(
+    () => setRemoteChangeDetected(false),
+    []
+  )
+
+  const save = useCallback(
+    async <T>(
+      saveFn: (expectedModifiedAt?: string) => Promise<T>
+    ): Promise<SaveOutcome<T>> => {
+      pendingSaveRef.current = saveFn as (
+        expectedModifiedAt?: string
+      ) => Promise<unknown>
+      try {
+        const data = await saveFn(baselineRef.current ?? undefined)
+        const row = data as unknown as
+          | Record<string, unknown>
+          | null
+          | undefined
+        const nextModifiedAt = row?.[modifiedAtColumn]
+        if (typeof nextModifiedAt === 'string')
+          baselineRef.current = nextModifiedAt
+        setConflict(false)
+        return { status: 'saved', data }
+      } catch (err) {
+        if (err instanceof ConcurrencyConflictError) {
+          setConflict(true)
+          return { status: 'conflict' }
+        }
+        throw err
+      }
+    },
+    [modifiedAtColumn]
+  )
+
+  const resolveConflict = useCallback(
+    async (choice: ConflictChoice) => {
+      // Not a full audit trail — just don't let the choice vanish silently.
+      console.info(
+        `[use-record-edit-session] conflict on ${table}:${recordId} resolved as "${choice}"`
+      )
+
+      if (choice === 'reload') {
+        if (recordId === null || recordId === undefined) return
+        setReloading(true)
+        try {
+          // biome-ignore lint/suspicious/noExplicitAny: table is a runtime string; this hook is intentionally schema-agnostic
+          const { data, error } = await (db.from(table) as any)
+            .select('*')
+            .eq(idColumn, recordId)
+            .single()
+          if (!error && data) {
+            const freshRow = data as TRow
+            const freshModifiedAt = freshRow[modifiedAtColumn]
+            if (typeof freshModifiedAt === 'string')
+              baselineRef.current = freshModifiedAt
+            onReload?.(freshRow)
+          } else if (error) {
+            console.warn('[use-record-edit-session] reload fetch failed', error)
+          }
+        } finally {
+          setReloading(false)
+          setConflict(false)
+          setRemoteChangeDetected(false)
+          pendingSaveRef.current = null
+        }
+        return
+      }
+
+      // Overwrite anyway: retry the last save with no compare-and-swap guard.
+      const fn = pendingSaveRef.current
+      setConflict(false)
+      setRemoteChangeDetected(false)
+      if (!fn) return
+      const data = await fn(undefined)
+      const row = data as unknown as Record<string, unknown> | null | undefined
+      const nextModifiedAt = row?.[modifiedAtColumn]
+      if (typeof nextModifiedAt === 'string')
+        baselineRef.current = nextModifiedAt
+      pendingSaveRef.current = null
+    },
+    [db, table, idColumn, modifiedAtColumn, recordId, onReload]
+  )
+
+  return {
+    peers,
+    remoteChangeDetected,
+    dismissRemoteChange,
+    conflict,
+    save,
+    resolveConflict,
+    reloading
+  }
+}

--- a/frontend/hooks/use-tanks.ts
+++ b/frontend/hooks/use-tanks.ts
@@ -2,13 +2,13 @@
 
 import { createClient } from '@/lib/supabase/client'
 import {
+  type TankInsert,
+  type TankUpdate,
+  type TankWithLatestReading,
   createTank,
   deleteTank,
   findAllTanks,
-  updateTank,
-  type TankInsert,
-  type TankUpdate,
-  type TankWithLatestReading
+  updateTank
 } from '@/repositories/tanks.repo'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
@@ -32,8 +32,15 @@ export function useTanks() {
   })
 
   const updateMutation = useMutation({
-    mutationFn: ({ tankId, updates }: { tankId: string; updates: TankUpdate }) =>
-      updateTank(db, tankId, updates),
+    mutationFn: ({
+      tankId,
+      updates,
+      expectedModifiedAt
+    }: {
+      tankId: string
+      updates: TankUpdate
+      expectedModifiedAt?: string
+    }) => updateTank(db, tankId, updates, expectedModifiedAt),
     onSuccess: () => qc.invalidateQueries({ queryKey: tankKeys.all })
   })
 
@@ -43,12 +50,15 @@ export function useTanks() {
   })
 
   return {
-    tanks: query.data ?? [] as TankWithLatestReading[],
+    tanks: query.data ?? ([] as TankWithLatestReading[]),
     loading: query.isLoading,
     error: query.error,
     createTank: (tank: TankInsert) => createMutation.mutateAsync(tank),
-    updateTank: (tankId: string, updates: TankUpdate) =>
-      updateMutation.mutateAsync({ tankId, updates }),
+    updateTank: (
+      tankId: string,
+      updates: TankUpdate,
+      expectedModifiedAt?: string
+    ) => updateMutation.mutateAsync({ tankId, updates, expectedModifiedAt }),
     deleteTank: (tankId: string) => deleteMutation.mutateAsync(tankId),
     refetch: query.refetch
   }

--- a/frontend/hooks/use-transactions.ts
+++ b/frontend/hooks/use-transactions.ts
@@ -5,18 +5,19 @@ import {
   createTransaction,
   deleteTransaction as deleteTransactionRepo,
   findAllTransactions,
-  updateTransaction,
   type TransactionFilters,
   type TransactionInsert,
   type TransactionUpdate,
-  type TransactionWithRelations
+  type TransactionWithRelations,
+  updateTransaction
 } from '@/repositories/transactions.repo'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 export const transactionKeys = {
   all: ['transactions'] as const,
   lists: () => [...transactionKeys.all, 'list'] as const,
-  list: (filters?: TransactionFilters) => [...transactionKeys.lists(), filters] as const
+  list: (filters?: TransactionFilters) =>
+    [...transactionKeys.lists(), filters] as const
 }
 
 export function useTransactions(filters?: TransactionFilters) {
@@ -34,8 +35,15 @@ export function useTransactions(filters?: TransactionFilters) {
   })
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, updates }: { id: number; updates: TransactionUpdate }) =>
-      updateTransaction(db, id, updates),
+    mutationFn: ({
+      id,
+      updates,
+      expectedModifiedAt
+    }: {
+      id: number
+      updates: TransactionUpdate
+      expectedModifiedAt?: string
+    }) => updateTransaction(db, id, updates, expectedModifiedAt),
     onSuccess: () => qc.invalidateQueries({ queryKey: transactionKeys.all })
   })
 
@@ -45,12 +53,16 @@ export function useTransactions(filters?: TransactionFilters) {
   })
 
   return {
-    transactions: query.data ?? [] as TransactionWithRelations[],
+    transactions: query.data ?? ([] as TransactionWithRelations[]),
     loading: query.isLoading,
     error: query.error,
-    createTransaction: (tx: TransactionInsert) => createMutation.mutateAsync(tx),
-    updateTransaction: (id: number, updates: TransactionUpdate) =>
-      updateMutation.mutateAsync({ id, updates }),
+    createTransaction: (tx: TransactionInsert) =>
+      createMutation.mutateAsync(tx),
+    updateTransaction: (
+      id: number,
+      updates: TransactionUpdate,
+      expectedModifiedAt?: string
+    ) => updateMutation.mutateAsync({ id, updates, expectedModifiedAt }),
     deleteTransaction: (id: number) => deleteMutation.mutateAsync(id),
     refetch: query.refetch
   }

--- a/frontend/lib/concurrency.ts
+++ b/frontend/lib/concurrency.ts
@@ -1,0 +1,21 @@
+/**
+ * Thrown by repository update functions when an optimistic-concurrency
+ * compare-and-swap write matches zero rows — i.e. the record's `modified_at`
+ * no longer matches what was loaded into the edit form, because someone else
+ * saved a change in between.
+ *
+ * Callers should catch this specifically (not treat it as a generic write
+ * failure) and offer the user a choice to reload the latest data or
+ * overwrite anyway. See frontend/hooks/use-record-edit-session.ts.
+ */
+export class ConcurrencyConflictError extends Error {
+  readonly table: string
+  readonly recordId: string | number
+
+  constructor(table: string, recordId: string | number) {
+    super(`Concurrent edit conflict on ${table}:${recordId}`)
+    this.name = 'ConcurrencyConflictError'
+    this.table = table
+    this.recordId = recordId
+  }
+}

--- a/frontend/repositories/tanks.repo.ts
+++ b/frontend/repositories/tanks.repo.ts
@@ -1,5 +1,11 @@
+import { ConcurrencyConflictError } from '@/lib/concurrency'
+import type {
+  Database,
+  Tables,
+  TablesInsert,
+  TablesUpdate
+} from '@/types/database'
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { Database, Tables, TablesInsert, TablesUpdate } from '@/types/database'
 
 export type TankRow = Tables<'fuel_tank'>
 export type TankInsert = TablesInsert<'fuel_tank'>
@@ -9,8 +15,13 @@ export type TankWithLatestReading = TankRow & {
   latest_reading: { level: string; recorded_at: string } | null
 }
 
-export async function findAllTanks(db: SupabaseClient<Database>): Promise<TankWithLatestReading[]> {
-  const { data: tanks, error } = await db.from('fuel_tank').select('*').order('tank_id')
+export async function findAllTanks(
+  db: SupabaseClient<Database>
+): Promise<TankWithLatestReading[]> {
+  const { data: tanks, error } = await db
+    .from('fuel_tank')
+    .select('*')
+    .order('tank_id')
   if (error) throw error
 
   // Fetch latest reading per tank
@@ -47,23 +58,40 @@ export async function createTank(
   db: SupabaseClient<Database>,
   tank: TankInsert
 ): Promise<TankRow> {
-  const { data, error } = await db.from('fuel_tank').insert(tank).select().single()
+  const { data, error } = await db
+    .from('fuel_tank')
+    .insert(tank)
+    .select()
+    .single()
   if (error) throw error
   return data
 }
 
+/**
+ * Update a tank. When `expectedModifiedAt` is provided, the write is an
+ * atomic compare-and-swap: it only applies if the row's `modified_at` still
+ * matches what the caller loaded. If someone else saved a change in between,
+ * zero rows match and this throws ConcurrencyConflictError instead of
+ * silently overwriting their edit. Omit `expectedModifiedAt` to write
+ * unconditionally (e.g. the "overwrite anyway" path).
+ */
 export async function updateTank(
   db: SupabaseClient<Database>,
   tankId: string,
-  updates: TankUpdate
+  updates: TankUpdate,
+  expectedModifiedAt?: string
 ): Promise<TankRow> {
-  const { data, error } = await db
-    .from('fuel_tank')
-    .update(updates)
-    .eq('tank_id', tankId)
-    .select()
-    .single()
-  if (error) throw error
+  let query = db.from('fuel_tank').update(updates).eq('tank_id', tankId)
+  if (expectedModifiedAt) {
+    query = query.eq('modified_at', expectedModifiedAt)
+  }
+  const { data, error } = await query.select().single()
+  if (error) {
+    if (expectedModifiedAt && error.code === 'PGRST116') {
+      throw new ConcurrencyConflictError('fuel_tank', tankId)
+    }
+    throw error
+  }
   return data
 }
 

--- a/frontend/repositories/transactions.repo.ts
+++ b/frontend/repositories/transactions.repo.ts
@@ -1,5 +1,11 @@
+import { ConcurrencyConflictError } from '@/lib/concurrency'
+import type {
+  Database,
+  Tables,
+  TablesInsert,
+  TablesUpdate
+} from '@/types/database'
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { Database, Tables, TablesInsert, TablesUpdate } from '@/types/database'
 
 export type TransactionRow = Tables<'fuel_transaction'>
 export type TransactionInsert = TablesInsert<'fuel_transaction'>
@@ -71,23 +77,40 @@ export async function createTransaction(
   db: SupabaseClient<Database>,
   tx: TransactionInsert
 ): Promise<TransactionRow> {
-  const { data, error } = await db.from('fuel_transaction').insert(tx).select().single()
+  const { data, error } = await db
+    .from('fuel_transaction')
+    .insert(tx)
+    .select()
+    .single()
   if (error) throw error
   return data
 }
 
+/**
+ * Update a transaction. When `expectedModifiedAt` is provided, the write is
+ * an atomic compare-and-swap: it only applies if the row's `modified_at`
+ * still matches what the caller loaded. If someone else saved a change in
+ * between, zero rows match and this throws ConcurrencyConflictError instead
+ * of silently overwriting their edit. Omit `expectedModifiedAt` to write
+ * unconditionally (e.g. the "overwrite anyway" path).
+ */
 export async function updateTransaction(
   db: SupabaseClient<Database>,
   id: number,
-  updates: TransactionUpdate
+  updates: TransactionUpdate,
+  expectedModifiedAt?: string
 ): Promise<TransactionRow> {
-  const { data, error } = await db
-    .from('fuel_transaction')
-    .update(updates)
-    .eq('id', id)
-    .select()
-    .single()
-  if (error) throw error
+  let query = db.from('fuel_transaction').update(updates).eq('id', id)
+  if (expectedModifiedAt) {
+    query = query.eq('modified_at', expectedModifiedAt)
+  }
+  const { data, error } = await query.select().single()
+  if (error) {
+    if (expectedModifiedAt && error.code === 'PGRST116') {
+      throw new ConcurrencyConflictError('fuel_transaction', id)
+    }
+    throw error
+  }
   return data
 }
 

--- a/frontend/scripts/modified-at-triggers.sql
+++ b/frontend/scripts/modified-at-triggers.sql
@@ -1,0 +1,74 @@
+-- Edit-Concurrency: modified_at triggers
+-- Run this in the Supabase SQL Editor (supabase.com/dashboard → SQL Editor).
+--
+-- Guarantees `modified_at` changes on every UPDATE to fuel_tank / fuel_transaction,
+-- at the database level, regardless of write path.
+--
+-- Why this is needed: both tables' modified_at columns were historically maintained
+-- by Django's `auto_now=True`, which is enforced by the Django ORM at save() time —
+-- it does nothing for writes that don't go through the ORM. The frontend writes these
+-- two tables directly via Supabase PostgREST (see frontend/repositories/tanks.repo.ts,
+-- transactions.repo.ts), which never touches the Django ORM, so `modified_at` was
+-- previously never updated by those writes.
+--
+-- That makes `modified_at` unreliable as the optimistic-concurrency compare-and-swap
+-- guard used by frontend/hooks/use-record-edit-session.ts: a stale value would either
+-- never match (permanent false-positive conflicts) or two racing writes could both
+-- "succeed" against the same stale value depending on client state. A BEFORE UPDATE
+-- trigger fixes this at the one place all writes funnel through — the database itself.
+--
+-- Scope: intentionally limited to the two tables touched by the current
+-- optimistic-concurrency work (fuel-farm tanks, fuel-dispatch transactions). Other
+-- tables with modified_at/created_at auto_now fields (equipment, training, invoicing,
+-- etc.) have the same gap if/when they're written to directly via Supabase, but are
+-- out of scope here — see docs/edit-concurrency.md for the note to future adopters.
+-- set_modified_at() is a generic, reusable function so wiring up additional tables
+-- later is a two-line trigger, not a new migration.
+--
+-- This project is Supabase-native (not Django-managed) — see project convention in
+-- other frontend/scripts/*.sql files. This was originally authored as a Django
+-- migration (`migrations.RunSQL`); converted to a plain script here since the
+-- project has fully decoupled from Django.
+
+-- ============================================================
+-- 1. Trigger function
+-- ============================================================
+CREATE OR REPLACE FUNCTION set_modified_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.modified_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================
+-- 2. Triggers
+-- ============================================================
+DROP TRIGGER IF EXISTS trg_fuel_tank_set_modified_at ON fuel_tank;
+CREATE TRIGGER trg_fuel_tank_set_modified_at
+    BEFORE UPDATE ON fuel_tank
+    FOR EACH ROW EXECUTE FUNCTION set_modified_at();
+
+DROP TRIGGER IF EXISTS trg_fuel_transaction_set_modified_at ON fuel_transaction;
+CREATE TRIGGER trg_fuel_transaction_set_modified_at
+    BEFORE UPDATE ON fuel_transaction
+    FOR EACH ROW EXECUTE FUNCTION set_modified_at();
+
+-- ============================================================
+-- 3. Realtime: register both tables so the frontend can subscribe to
+--    postgres_changes for live "someone just edited this" detection.
+--    No-op if the publication doesn't exist (e.g. plain Postgres in tests/CI).
+-- ============================================================
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime') THEN
+        BEGIN
+            ALTER PUBLICATION supabase_realtime ADD TABLE fuel_tank;
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END;
+        BEGIN
+            ALTER PUBLICATION supabase_realtime ADD TABLE fuel_transaction;
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END;
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Scoped port of PR #20 (`worktree-agent-a09c16d944f95856a`), which was rooted 36 commits behind current master — a direct merge would have reverted a large amount of already-merged work.
- Adds a reusable `useRecordEditSession` hook (Supabase Realtime presence + atomic compare-and-swap save via `UPDATE ... WHERE modified_at = expected` + live `postgres_changes` subscription) and an `EditSessionStatus` UI component, so concurrent Sheet edits surface a reload/overwrite choice instead of silently clobbering each other.
- Wires the pattern into `tank-form-dialog.tsx` and `transaction-form-dialog.tsx` as reference implementations. Both had been independently rewritten since PR #20 branched (tank-form-dialog by the Sheet-slideout migration in #22, transaction-form-dialog by the fuel-orders-module rebuild) — the edit-concurrency wiring was manually re-applied on top of their current content rather than blindly merged, to avoid reverting that work. Also fixed a stale `FuelTransactionCreateRequest` (old Django-API-client type) reference in `app/dispatch/page.tsx` that would have shipped from PR #20's outdated branch content — corrected to `TransactionInsert` to match the current data layer.
- **Django → raw SQL conversion**: the `modified_at` trigger was originally authored as a Django migration (`backend/api/migrations/0003_modified_at_triggers.py`). Converted to `frontend/scripts/modified-at-triggers.sql` per the project's no-Django convention (the migration file was dropped, not included in this PR) and updated `docs/edit-concurrency.md`'s references accordingly.
- Applied `modified-at-triggers.sql` directly to the live Supabase DB — verified the `BEFORE UPDATE` triggers exist on `fuel_tank`/`fuel_transaction` and both tables are registered with the `supabase_realtime` publication.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `next build` passes (`/dispatch`, `/fuel-farm`, `/fuel-dispatch` routes present)
- [x] SQL trigger script applied to live DB, verified via `\d fuel_tank` / `pg_publication_tables`