### PR TITLE
test: refuse to run repository tests against anything but localhost

### DIFF
--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -59,15 +59,31 @@ pnpm supabase:stop
   one local database — running them concurrently would let one file's reset wipe rows another
   file is mid-assertion on.
 
+## Safety: this suite deletes data — it can only target loopback
+
+`resetDatabase()` truncates every table it knows about before every test. That's only safe
+because `tests/support/client.ts` refuses to construct a test client (`createTestClient()`)
+against anything that isn't `127.0.0.1`/`localhost`/`::1` — and `resetDatabase()` independently
+re-checks the same guard right before it deletes anything, as defense in depth in case a client
+ever gets built another way. Pointing `SUPABASE_TEST_URL` at a real project URL (e.g. by
+copy-pasting from `.env.local`, or a stale CI secret) fails loudly at client construction,
+**before any test body or delete runs** — it does not silently wipe whatever's on the other end.
+
 ## Pointing at a different Postgres/PostgREST instance (e.g. CI)
 
-Override the defaults with env vars if you don't want to run the Supabase CLI stack directly:
+Override the defaults with env vars if you don't want to run the Supabase CLI stack directly.
+Because of the guard above, a non-loopback URL alone isn't enough — you also need the explicit
+opt-in flag, so this only works if you mean it:
 
 ```bash
-SUPABASE_TEST_URL=http://localhost:54321 \
+SUPABASE_TEST_URL=http://some-disposable-ci-instance:54321 \
 SUPABASE_TEST_SERVICE_ROLE_KEY=... \
+SUPABASE_TEST_ALLOW_REMOTE=yes-i-am-sure \
 pnpm test:repos
 ```
+
+Never set `SUPABASE_TEST_ALLOW_REMOTE` against anything that isn't a disposable/throwaway
+instance — this suite will delete every row in it.
 
 ## Coverage
 

--- a/frontend/tests/support/client.ts
+++ b/frontend/tests/support/client.ts
@@ -15,6 +15,38 @@ export const TEST_SUPABASE_URL = process.env.SUPABASE_TEST_URL ?? LOCAL_URL
 const TEST_SERVICE_ROLE_KEY = process.env.SUPABASE_TEST_SERVICE_ROLE_KEY ?? LOCAL_SERVICE_ROLE_KEY
 export const TEST_ANON_KEY = process.env.SUPABASE_TEST_ANON_KEY ?? LOCAL_ANON_KEY
 
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '[::1]'])
+
+/**
+ * This test suite wipes every table it touches (see resetDatabase in ./reset.ts) — that's
+ * only safe because it's aimed at a throwaway local Postgres container. Refuse to run
+ * against anything that isn't loopback unless the caller opts in with BOTH an explicit
+ * non-local SUPABASE_TEST_URL *and* this confirmation flag, so pointing the suite at the
+ * wrong database takes two deliberate actions instead of one env var typo/copy-paste.
+ */
+export function assertSafeTestTarget(url: string): void {
+  let host: string
+  try {
+    host = new URL(url).hostname
+  } catch {
+    throw new Error(`SUPABASE_TEST_URL is not a valid URL: "${url}"`)
+  }
+
+  if (LOOPBACK_HOSTS.has(host)) return
+
+  if (process.env.SUPABASE_TEST_ALLOW_REMOTE !== 'yes-i-am-sure') {
+    throw new Error(
+      `Refusing to run repository tests against "${url}" — this suite calls resetDatabase(), ` +
+        'which deletes every row in every table it knows about (tanks, transactions, users, ' +
+        'invoices, ...). This is only safe against the local Supabase stack (127.0.0.1).\n\n' +
+        'If you really mean to point this at a different disposable instance (e.g. a CI-only ' +
+        'throwaway DB, never the live/shared project), set BOTH:\n' +
+        '  SUPABASE_TEST_URL=<url>\n' +
+        '  SUPABASE_TEST_ALLOW_REMOTE=yes-i-am-sure'
+    )
+  }
+}
+
 /**
  * Service-role client for repository integration tests. Bypasses RLS (there is none
  * defined in the test schema anyway) the same way server-side repository callers do
@@ -23,9 +55,11 @@ export const TEST_ANON_KEY = process.env.SUPABASE_TEST_ANON_KEY ?? LOCAL_ANON_KE
  *
  * Points at the local Supabase stack started via `pnpm supabase:start` by default.
  * Override with SUPABASE_TEST_URL / SUPABASE_TEST_SERVICE_ROLE_KEY to run against a
- * different disposable Postgres+PostgREST instance (e.g. in CI).
+ * different disposable Postgres+PostgREST instance (e.g. in CI) — see
+ * assertSafeTestTarget() above for the guard rail on that override.
  */
 export function createTestClient(): SupabaseClient<Database> {
+  assertSafeTestTarget(TEST_SUPABASE_URL)
   return createClient<Database>(TEST_SUPABASE_URL, TEST_SERVICE_ROLE_KEY, {
     auth: { persistSession: false, autoRefreshToken: false },
   })

--- a/frontend/tests/support/reset.ts
+++ b/frontend/tests/support/reset.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '@/types/database'
+import { TEST_SUPABASE_URL, assertSafeTestTarget } from './client'
 
 // Deletion order: children before parents, so FK constraints never block a wipe.
 // Keep this in sync with frontend/supabase/migrations/*.sql.
@@ -37,6 +38,12 @@ const RESET_ORDER: Array<{ table: keyof Database['public']['Tables']; pk: string
  * instead of tagging/filtering rows in a shared dataset.
  */
 export async function resetDatabase(db: SupabaseClient<Database>): Promise<void> {
+  // Defense in depth: re-check the guard from client.ts even though createTestClient()
+  // already checks it at construction time — this is the function that actually deletes
+  // rows, so it re-validates independently rather than trusting the caller went through
+  // the guarded factory.
+  assertSafeTestTarget(TEST_SUPABASE_URL)
+
   for (const { table, pk } of RESET_ORDER) {
     const { error } = await db.from(table).delete().not(pk, 'is', null)
     if (error) {


### PR DESCRIPTION
## Summary

Follow-up to #25. That PR's `resetDatabase()` truncates every table it knows about before each test — safe by default (it only ever talks to the local Postgres container `pnpm supabase:start` spins up), but the `SUPABASE_TEST_URL` override meant for CI had no guard rail. A copy-pasted or misconfigured URL pointing at the real project would have silently wiped it with zero confirmation.

- `createTestClient()` now refuses to construct a client for anything that isn't `127.0.0.1`/`localhost`/`::1`, unless the caller sets **both** a non-local `SUPABASE_TEST_URL` and an explicit `SUPABASE_TEST_ALLOW_REMOTE=yes-i-am-sure`.
- `resetDatabase()` independently re-checks the same guard right before it deletes anything, as defense in depth.
- Fails loudly at client construction — before any test body or delete call runs — with an error explaining exactly why and how to opt in deliberately.
- `frontend/tests/README.md` documents the guarantee.

## Test plan

- [x] `pnpm test:repos` → 16 files, 96 tests passed (unaffected — default path is still loopback)
- [x] `pnpm exec tsc --noEmit` → clean
- [x] Manually verified: `SUPABASE_TEST_URL=https://<a-real-looking-project>.supabase.co pnpm exec vitest run repositories/__tests__/equipment.repo.test.ts` fails immediately with the guard's error, 0 tests run, no delete calls made