### PR TITLE
test: Playwright E2E layer proving forms actually persist to the DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,13 @@ coverage/
 .pytest_cache/
 .ruff_cache
 
+# Playwright E2E (frontend/e2e) — local run artifacts and saved login sessions,
+# never something to commit even though the target is a throwaway local stack
+frontend/test-results/
+frontend/playwright-report/
+frontend/blob-report/
+frontend/e2e/.auth/
+
 # -----------------------------
 # Editors / IDEs / Local tooling
 # -----------------------------

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -1,0 +1,92 @@
+# End-to-end tests (Playwright)
+
+`frontend/tests/` (vitest) proves the repository layer's queries are correct against a real
+schema. This directory proves something different and non-overlapping: that the **UI actually
+calls the repository layer and the record actually lands in the database** — driving the real
+Next.js app in a real browser through a real Supabase Auth login, not mocked fetches and not a
+stubbed session.
+
+This exists specifically for the bug class repository tests structurally cannot catch: a form
+that renders correctly, shows no error, and *looks* like it saved — but never actually persisted.
+The 2026-07-03 session handoff named exactly this: *"a POS/invoicing ticket-entry form that
+renders and looks correct but silently doesn't persist to the database."* Every spec here ends
+with a direct DB read (service-role client, bypassing the UI entirely) as the actual proof —
+the UI "looking like it worked" is never treated as sufficient on its own.
+
+## One-time setup
+
+Same local Supabase stack as the vitest repo suite (`frontend/tests/README.md`), with Auth
+enabled — the E2E layer logs in for real, so `supabase/config.toml` has `[auth] enabled = true`
+here (the vitest suite doesn't need it, but doesn't mind it being on either).
+
+```bash
+cd frontend
+pnpm install
+pnpm exec playwright install chromium --with-deps   # first run only
+pnpm supabase:start
+pnpm supabase:reset    # make sure all migrations (incl. user-management) are applied
+```
+
+## Running
+
+```bash
+pnpm e2e            # headless, all specs
+pnpm e2e:ui          # Playwright's interactive UI mode — best for writing/debugging specs
+```
+
+No `.env` file needed — `playwright.config.ts` launches `next dev` itself with
+`NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY` injected directly, pointed at the
+local stack (`e2e/support/env.ts`), on port 3100 so it never collides with a real `pnpm dev`.
+
+## How auth works
+
+The login form (`components/forms/login-form.tsx`) already ships two **"Quick Dev Login"**
+buttons wired to `admin@fbo.local` / `user@fbo.local`. `e2e/global-setup.ts` runs once before
+the whole suite:
+
+1. `e2e/support/seed.ts` creates those two accounts via the Supabase Admin API against the
+   local stack (idempotent — safe to run against an already-seeded stack) and grants them
+   roles from `frontend/scripts/user-management-schema.sql` (Administrator / Line Technician),
+   which is applied as `supabase/migrations/20260703000200_user_management_schema.sql`.
+2. For each account, launches a real browser, clicks the real dev-login button (a real
+   `supabase.auth.signInWithPassword` call, real cookies), and saves the session to
+   `e2e/.auth/{admin,user}.json` (gitignored).
+3. Specs pick a saved session via Playwright `projects` in `playwright.config.ts` — most
+   specs run under the `admin` project (full access to every module); specs that need to prove
+   *restricted* access belong under `e2e/user-role/**` and run against the `line-technician`
+   project instead.
+
+## Safety
+
+Same principle as the vitest suite's `assertSafeTestTarget` (`tests/support/client.ts`):
+`e2e/support/env.ts`'s `assertSafeE2ETarget` refuses to seed users or run against anything
+that isn't `127.0.0.1`/`localhost` unless both `E2E_SUPABASE_URL` and
+`E2E_ALLOW_REMOTE=yes-i-am-sure` are set explicitly. This suite creates real records through
+the real app — never point it at a shared or production project.
+
+## Test data
+
+Unlike the vitest repo suite, specs here do **not** wipe the database between runs — doing so
+would delete the seeded auth users/profiles/roles and log every session out mid-suite. Instead,
+every spec generates unique fixture values (`e2e/support/unique.ts`, mirroring
+`tests/support/factories.ts`'s pattern) so repeated runs against the same persistent local DB
+never collide. Periodically `pnpm supabase:reset` for a fully clean slate (global-setup
+re-seeds the dev accounts automatically on the next run).
+
+## Coverage
+
+| Flow | Spec | Notes |
+|---|---|---|
+| Equipment: create | `equipment.e2e.ts` | Simple CRUD form — the baseline smoke test proving the whole pipeline (login → form → DB) works |
+| Equipment: edit | `equipment.e2e.ts` | |
+| Invoicing: digital fuel ticket, "Complete ticket" | `invoicing.e2e.ts` | Highest priority — the exact form/bug class named in the 2026-07-03 handoff. Verifies the invoice, its line item, *and* the fueling event (`truck_meter_readings`) it creates as a side effect, plus the `invoice_number` stamped back onto that reading |
+
+**Not yet covered** — every other create/edit form in the app (aircraft, flights, parking
+locations, tanks/tank readings, trainings/certifications, fuelers, truck sheets manual entry,
+transactions/fuel-dispatch, user management, training-compliance module, invoicing draft-save
+and settle/void flows). The infrastructure this PR adds (seeded auth, storage-state reuse, DB
+verification helpers) is the expensive part and is done — extending coverage to another form is
+now a matter of writing one spec per form following `equipment.e2e.ts`'s pattern, not more
+plumbing. Prioritize by risk: forms with complex multi-step writes (like invoicing's) are worth
+more than simple single-table CRUD forms, which the vitest repo suite already indirectly proves
+work at the query level.

--- a/frontend/e2e/equipment.e2e.ts
+++ b/frontend/e2e/equipment.e2e.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test'
+import { createE2EDbClient, waitForDbRow } from './support/db'
+import { uniqueValue } from './support/unique'
+
+const db = createE2EDbClient()
+
+test.describe('Equipment form — create and edit actually persist', () => {
+  test('Add Equipment form creates a real row in the database', async ({ page }) => {
+    const equipmentId = uniqueValue('E2E-EQ-')
+    const equipmentName = uniqueValue('E2E Fuel Truck ')
+
+    await page.goto('/equipment')
+    await page.getByRole('button', { name: 'Add Equipment' }).click()
+
+    await page.getByLabel('Equipment ID').fill(equipmentId)
+    await page.getByLabel('Name').fill(equipmentName)
+    await page.getByLabel('Manufacturer').fill('E2E Manufacturer')
+    await page.getByLabel('Model').fill('E2E Model')
+    await page.getByRole('button', { name: 'Add Equipment' }).click()
+
+    // The dialog closing on its own (no leftover error toast, no still-open sheet) is the
+    // first signal the submit "succeeded" from the UI's point of view — exactly the point
+    // where the known bug class hides: this can happen even if nothing was persisted.
+    await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 10_000 })
+
+    // The only proof that matters: a real row exists in the database with this data.
+    const row = await waitForDbRow(async () => {
+      const { data } = await db.from('equipment').select('*').eq('equipment_id', equipmentId).maybeSingle()
+      return data
+    })
+    expect(row.equipment_name).toBe(equipmentName)
+    expect(row.manufacturer).toBe('E2E Manufacturer')
+
+    // And the UI list reflects the same row, not just a locally-optimistic one.
+    await expect(page.getByText(equipmentName)).toBeVisible()
+  })
+
+  test('Editing equipment persists the change to the database', async ({ page }) => {
+    const equipmentId = uniqueValue('E2E-EQ-EDIT-')
+    const originalName = uniqueValue('E2E Original Name ')
+    const updatedName = uniqueValue('E2E Updated Name ')
+
+    const { error } = await db.from('equipment').insert({
+      equipment_id: equipmentId,
+      equipment_name: originalName,
+      equipment_type: 'fuel_truck',
+    })
+    if (error) throw error
+
+    await page.goto('/equipment')
+    // Each card has its own "Edit" button (components/equipment/equipment-status-card.tsx)
+    // — the name text itself isn't clickable, so scope to the specific card by its
+    // distinguishing class and click that card's Edit button.
+    const card = page.locator('.border-l-4').filter({ hasText: originalName })
+    await card.getByRole('button', { name: 'Edit' }).click()
+
+    const nameField = page.getByLabel('Name')
+    await nameField.fill(updatedName)
+    await page.getByRole('button', { name: 'Save Changes' }).click()
+
+    await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 10_000 })
+
+    const row = await waitForDbRow(async () => {
+      const { data } = await db.from('equipment').select('*').eq('equipment_id', equipmentId).maybeSingle()
+      return data?.equipment_name === updatedName ? data : null
+    })
+    expect(row.equipment_name).toBe(updatedName)
+  })
+})

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -1,0 +1,34 @@
+import path from 'node:path'
+import { chromium, type FullConfig } from '@playwright/test'
+import { DEV_USERS, E2E_BASE_URL } from './support/env'
+import { seedDevUsers } from './support/seed'
+
+export const AUTH_DIR = path.join(__dirname, '.auth')
+export const ADMIN_STORAGE_STATE = path.join(AUTH_DIR, 'admin.json')
+export const USER_STORAGE_STATE = path.join(AUTH_DIR, 'user.json')
+
+/**
+ * Runs once before the whole E2E suite: seeds the two dev accounts the login form's
+ * "Quick Dev Login" buttons already target, then logs each in through the real UI (real
+ * Supabase Auth request, real cookies) and saves the resulting session so individual specs
+ * can start already authenticated instead of re-logging-in every test.
+ */
+export default async function globalSetup(_config: FullConfig): Promise<void> {
+  await seedDevUsers()
+
+  const browser = await chromium.launch()
+
+  for (const [storageState, devUser] of [
+    [ADMIN_STORAGE_STATE, DEV_USERS.admin],
+    [USER_STORAGE_STATE, DEV_USERS.user],
+  ] as const) {
+    const page = await browser.newPage({ baseURL: E2E_BASE_URL })
+    await page.goto('/login')
+    await page.getByRole('button', { name: devUser === DEV_USERS.admin ? 'Log in as Admin' : 'Log in as User' }).click()
+    await page.waitForURL(`${E2E_BASE_URL}/`, { timeout: 15_000 })
+    await page.context().storageState({ path: storageState })
+    await page.close()
+  }
+
+  await browser.close()
+}

--- a/frontend/e2e/invoicing.e2e.ts
+++ b/frontend/e2e/invoicing.e2e.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test'
+import { createE2EDbClient, waitForDbRow } from './support/db'
+import { uniqueValue } from './support/unique'
+
+const db = createE2EDbClient()
+
+/**
+ * This is the module the 2026-07-03 handoff explicitly flagged: "a POS/invoicing
+ * ticket-entry form that renders and looks correct but silently doesn't persist to the
+ * database." createInvoice() (repositories/invoices.repo.ts) does a multi-step write —
+ * fueling event -> invoice -> line items -> gauge readings, with best-effort rollback since
+ * supabase-js has no client transactions — driven entirely through client state in
+ * components/invoicing/fuel-ticket-sheet.tsx. A repository-layer test can prove the
+ * function works; only driving the actual form proves the UI actually calls it.
+ */
+test.describe('Fuel ticket entry — Complete ticket actually persists', () => {
+  test('a digitally-entered fuel ticket creates a real invoice, line item, and fueling event', async ({
+    page,
+  }) => {
+    const truckId = uniqueValue('E2E-TRK-')
+    const { error: truckError } = await db
+      .from('equipment')
+      .insert({ equipment_id: truckId, equipment_name: `E2E Truck ${truckId}`, equipment_type: 'fuel_truck' })
+    if (truckError) throw truckError
+
+    const invoiceNumber = uniqueValue('E2E-INV-')
+    const customerName = uniqueValue('E2E Walk-up ')
+
+    await page.goto('/invoicing')
+    await page.getByRole('button', { name: 'New ticket' }).click()
+
+    const invoiceNumberField = page.getByLabel('Invoice #')
+    await invoiceNumberField.fill(invoiceNumber)
+
+    // Customer combobox: write-in flow (no linked account needed for cash).
+    await page.getByRole('button', { name: 'Customer name' }).click()
+    await page.getByPlaceholder('Search accounts or type a name…').fill(customerName)
+    // Curly quotes in the source ("Use “X” as written") — match on the stable part only.
+    await page.getByText(new RegExp(`as written`)).click()
+
+    // Fuel truck select (fuel delivery is on by default).
+    await page.getByRole('combobox', { name: 'Fuel truck' }).click()
+    await page.getByRole('option', { name: new RegExp(truckId) }).click()
+
+    await page.getByLabel('Quantity (gal)').fill('150')
+    await page.getByLabel('Price / gal').fill('6.25')
+
+    // Click the (larger) <Label htmlFor="pay-cash"> rather than the sr-only radio input
+    // itself — the radio's own hit area is small enough to occasionally get reported as
+    // covered by the sheet's overlay during the Select's closing animation.
+    await page.locator('label[for="pay-cash"]').click()
+
+    await page.getByRole('button', { name: 'Complete ticket' }).click()
+
+    // The sheet closing without a form error is the "looks like it worked" signal that
+    // hid the original bug — the DB read below is what actually proves it.
+    await expect(page.getByText('Invoice number and customer name are required')).not.toBeVisible()
+    await expect(page.getByRole('button', { name: 'Complete ticket' })).not.toBeVisible({ timeout: 10_000 })
+
+    const invoice = await waitForDbRow(async () => {
+      const { data } = await db
+        .from('invoices')
+        .select('*, invoice_line_items(*)')
+        .eq('invoice_number', invoiceNumber)
+        .maybeSingle()
+      return data
+    })
+    expect(invoice.customer_name).toBe(customerName)
+    expect(invoice.status).toBe('paid') // finalize + cash => paid (see invoices.repo.ts statusFor())
+    expect(Number(invoice.total)).toBeCloseTo(150 * 6.25, 2)
+
+    const lineItems = invoice.invoice_line_items as Array<{
+      item_type: string
+      truck_meter_reading_id: number | null
+      quantity: number
+    }>
+    expect(lineItems).toHaveLength(1)
+    expect(lineItems[0].item_type).toBe('fuel')
+    expect(Number(lineItems[0].quantity)).toBe(150)
+
+    // The fueling event itself: a real, independently-queryable truck_meter_readings row,
+    // not just a client-side number that never made it to the database.
+    const readingId = lineItems[0].truck_meter_reading_id
+    expect(readingId).not.toBeNull()
+    const { data: reading } = await db
+      .from('truck_meter_readings')
+      .select('*')
+      .eq('id', readingId as number)
+      .single()
+    expect(reading?.gallons_pumped).toBe(150)
+    expect(reading?.invoice_number).toBe(invoiceNumber)
+  })
+})

--- a/frontend/e2e/support/db.ts
+++ b/frontend/e2e/support/db.ts
@@ -1,0 +1,36 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/types/database'
+import { E2E_SUPABASE_SERVICE_ROLE_KEY, E2E_SUPABASE_URL, assertSafeE2ETarget } from './env'
+
+/**
+ * Service-role client for asserting on DB state directly from a spec — e.g. "after
+ * submitting the create-equipment form, does a matching row actually exist?" This is the
+ * crux of what this whole E2E layer is for: a form can render successfully and show a
+ * success toast while silently never having called the repository/persistence path. Only
+ * a real DB read after the UI interaction proves it worked.
+ */
+export function createE2EDbClient(): SupabaseClient<Database> {
+  assertSafeE2ETarget(E2E_SUPABASE_URL)
+  return createClient<Database>(E2E_SUPABASE_URL, E2E_SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+}
+
+/** Polls until `check` returns a truthy value or the timeout elapses — for the gap between
+ * a form's submit handler returning and the row actually landing (revalidation, redirect). */
+export async function waitForDbRow<T>(
+  check: () => Promise<T | null>,
+  { timeoutMs = 10_000, intervalMs = 250 }: { timeoutMs?: number; intervalMs?: number } = {}
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs
+  let lastResult: T | null = null
+  while (Date.now() < deadline) {
+    lastResult = await check()
+    if (lastResult) return lastResult
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  throw new Error(
+    `waitForDbRow: no matching row appeared within ${timeoutMs}ms — the form likely rendered ` +
+      'success but did not actually persist (the exact bug class this suite exists to catch).'
+  )
+}

--- a/frontend/e2e/support/env.ts
+++ b/frontend/e2e/support/env.ts
@@ -1,0 +1,45 @@
+// Shared constants for the E2E layer: local Supabase stack connection info + the two
+// "Quick Dev Login" seed accounts the login form already wires up
+// (components/forms/login-form.tsx). These are the same standard Supabase CLI local-dev
+// demo keys used by frontend/tests/support/client.ts for the repository test suite — not
+// secrets, baked into every local Supabase CLI project's default JWT signing config.
+
+export const LOCAL_SUPABASE_URL = 'http://127.0.0.1:54321'
+const LOCAL_ANON_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0'
+const LOCAL_SERVICE_ROLE_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU'
+
+export const E2E_SUPABASE_URL = process.env.E2E_SUPABASE_URL ?? LOCAL_SUPABASE_URL
+export const E2E_SUPABASE_ANON_KEY = process.env.E2E_SUPABASE_ANON_KEY ?? LOCAL_ANON_KEY
+export const E2E_SUPABASE_SERVICE_ROLE_KEY =
+  process.env.E2E_SUPABASE_SERVICE_ROLE_KEY ?? LOCAL_SERVICE_ROLE_KEY
+
+// Next.js 16 dev server blocks cross-origin requests to _next/* dev resources from
+// anything but "localhost" by default (allowedDevOrigins) — 127.0.0.1 gets blocked even
+// though it's loopback, so this deliberately differs from the repo test suite's
+// 127.0.0.1-only convention.
+export const E2E_BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:3100'
+
+/**
+ * Same safety principle as tests/support/client.ts's assertSafeTestTarget: the E2E seed
+ * script creates real auth users (and, via the app under test, real DB rows) against
+ * whatever this points at. Only loopback is allowed by default.
+ */
+export function assertSafeE2ETarget(url: string): void {
+  const host = new URL(url).hostname
+  const loopback = host === '127.0.0.1' || host === 'localhost' || host === '::1'
+  if (loopback) return
+  if (process.env.E2E_ALLOW_REMOTE !== 'yes-i-am-sure') {
+    throw new Error(
+      `Refusing to run E2E setup against "${url}" — this seeds real auth users and drives ` +
+        'the real app against it. Only safe against the local Supabase stack (127.0.0.1). ' +
+        'Set E2E_SUPABASE_URL and E2E_ALLOW_REMOTE=yes-i-am-sure to override deliberately.'
+    )
+  }
+}
+
+export const DEV_USERS = {
+  admin: { email: 'admin@fbo.local', password: 'devadmin', role: 'Administrator' as const },
+  user: { email: 'user@fbo.local', password: 'devuser', role: 'Line Technician' as const },
+}

--- a/frontend/e2e/support/run-seed.ts
+++ b/frontend/e2e/support/run-seed.ts
@@ -1,0 +1,15 @@
+// Standalone entry point for `pnpm e2e:seed` — Playwright's globalSetup also calls
+// seedDevUsers() directly, this is just for seeding manually against a running local stack
+// without spinning up a full Playwright run (e.g. to poke around at http://127.0.0.1:3100
+// by hand with a working login).
+import { DEV_USERS } from './env'
+import { seedDevUsers } from './seed'
+
+seedDevUsers()
+  .then(() => {
+    console.log('Seeded dev users:', Object.values(DEV_USERS).map((u) => u.email).join(', '))
+  })
+  .catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })

--- a/frontend/e2e/support/seed.ts
+++ b/frontend/e2e/support/seed.ts
@@ -1,0 +1,56 @@
+import { createClient } from '@supabase/supabase-js'
+import {
+  DEV_USERS,
+  E2E_SUPABASE_SERVICE_ROLE_KEY,
+  E2E_SUPABASE_URL,
+  assertSafeE2ETarget,
+} from './env'
+
+/**
+ * Idempotently creates the two "Quick Dev Login" accounts the login form already offers
+ * (components/forms/login-form.tsx) via the Supabase Admin API, and grants each their role
+ * per frontend/scripts/user-management-schema.sql's `handle_new_auth_user` trigger (which
+ * auto-creates the `profiles` row — this only needs to add the `user_roles` grant on top).
+ *
+ * Safe to call every run: createUser on an existing email fails with a recognizable error
+ * that this treats as "already seeded," so this doubles as the reset-then-reseed step after
+ * `supabase db reset` and as a no-op on a stack that's already seeded.
+ */
+export async function seedDevUsers(): Promise<void> {
+  assertSafeE2ETarget(E2E_SUPABASE_URL)
+
+  const admin = createClient(E2E_SUPABASE_URL, E2E_SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+
+  for (const { email, password, role } of Object.values(DEV_USERS)) {
+    const { data: created, error: createError } = await admin.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+    })
+
+    let userId = created?.user?.id
+    if (createError) {
+      if (!/already been registered|already exists/i.test(createError.message)) {
+        throw new Error(`seedDevUsers: failed to create ${email}: ${createError.message}`)
+      }
+      const { data: list, error: listError } = await admin.auth.admin.listUsers()
+      if (listError) throw listError
+      userId = list.users.find((u) => u.email === email)?.id
+    }
+    if (!userId) throw new Error(`seedDevUsers: could not resolve auth user id for ${email}`)
+
+    const { data: roleRow, error: roleError } = await admin
+      .from('roles')
+      .select('id')
+      .eq('name', role)
+      .single()
+    if (roleError) throw new Error(`seedDevUsers: role "${role}" not found: ${roleError.message}`)
+
+    const { error: grantError } = await admin
+      .from('user_roles')
+      .upsert({ user_id: userId, role_id: roleRow.id }, { onConflict: 'user_id,role_id' })
+    if (grantError) throw new Error(`seedDevUsers: failed to grant ${role} to ${email}: ${grantError.message}`)
+  }
+}

--- a/frontend/e2e/support/unique.ts
+++ b/frontend/e2e/support/unique.ts
@@ -1,0 +1,9 @@
+let counter = 0
+
+/** Unique-enough suffix for E2E fixture data — the local DB persists across runs (no
+ * per-test reset, since that would blow away the seeded auth session), so test data needs
+ * to not collide with previous runs the way the vitest repo suite's rows don't need to. */
+export function uniqueValue(prefix: string): string {
+  counter += 1
+  return `${prefix}${Date.now().toString(36)}${counter}`
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,10 @@
     "test:repos": "vitest run repositories",
     "supabase:start": "supabase start",
     "supabase:stop": "supabase stop",
-    "supabase:reset": "supabase db reset"
+    "supabase:reset": "supabase db reset",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:seed": "tsx e2e/support/run-seed.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.110.0",
@@ -76,6 +79,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.1.9",
     "@types/node": "^20.17.10",
     "@types/react": "^19.0.2",
@@ -86,6 +90,7 @@
     "postcss": "^8.4.49",
     "supabase": "2.109.0",
     "tailwindcss": "^4.1.9",
+    "tsx": "^4.22.5",
     "tw-animate-css": "^1.3.3",
     "typescript": "5.7.2",
     "vitest": "^4.1.9"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,65 @@
+import path from 'node:path'
+import { defineConfig, devices } from '@playwright/test'
+import { ADMIN_STORAGE_STATE, USER_STORAGE_STATE } from './e2e/global-setup'
+import { E2E_BASE_URL, E2E_SUPABASE_ANON_KEY, E2E_SUPABASE_URL } from './e2e/support/env'
+
+/**
+ * Full-stack E2E layer: drives the real Next.js app in a real browser against the same
+ * local Supabase stack the repository integration tests use (see tests/README.md), through
+ * a real login (Supabase Auth, real cookies) — not mocked fetches, not a stubbed session.
+ *
+ * This exists specifically to catch the bug class repository-layer tests structurally
+ * cannot: a form that renders correctly and *looks* like it saved, but never actually calls
+ * the repository/persistence path, or swallows the error silently. See frontend/e2e/README.md.
+ *
+ * Prerequisite: `pnpm supabase:start` (same local stack as the vitest repo tests).
+ */
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: '**/*.e2e.ts',
+  fullyParallel: false, // forms create real rows against one shared local DB; keep runs predictable
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  globalSetup: require.resolve('./e2e/global-setup'),
+  timeout: 30_000,
+
+  use: {
+    baseURL: E2E_BASE_URL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'admin',
+      use: { ...devices['Desktop Chrome'], storageState: ADMIN_STORAGE_STATE },
+      testIgnore: '**/user-role/**',
+    },
+    {
+      name: 'line-technician',
+      use: { ...devices['Desktop Chrome'], storageState: USER_STORAGE_STATE },
+      testMatch: '**/user-role/**',
+    },
+  ],
+
+  webServer: {
+    command: `pnpm exec next dev -p ${new URL(E2E_BASE_URL).port}`,
+    url: E2E_BASE_URL,
+    // Always start a fresh server bound to the local test stack rather than reusing
+    // whatever might already be running on this port — reusing an existing dev server
+    // could mean silently running these tests (which create real records) against
+    // whatever backend *that* server happens to be configured for, live project included.
+    reuseExistingServer: false,
+    timeout: 120_000,
+    cwd: path.resolve(__dirname),
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL: E2E_SUPABASE_URL,
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: E2E_SUPABASE_ANON_KEY,
+      SUPABASE_URL: E2E_SUPABASE_URL,
+      SUPABASE_ANON_KEY: E2E_SUPABASE_ANON_KEY,
+      NEXT_TELEMETRY_DISABLED: '1',
+    },
+  },
+})

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -142,7 +142,7 @@ importers:
         version: 3.16.0
       next:
         specifier: ^16.2.9
-        version: 16.2.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.2.9(@playwright/test@1.61.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -183,6 +183,9 @@ importers:
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@tailwindcss/postcss':
         specifier: ^4.1.9
         version: 4.1.16
@@ -213,6 +216,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.9
         version: 4.1.16
+      tsx:
+        specifier: ^4.22.5
+        version: 4.22.5
       tw-animate-css:
         specifier: ^1.3.3
         version: 1.4.0
@@ -221,7 +227,7 @@ importers:
         version: 5.7.2
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@20.19.24)(vite@8.1.3(@types/node@20.19.24)(jiti@2.6.1))
+        version: 4.1.9(@types/node@20.19.24)(vite@8.1.3(@types/node@20.19.24)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.5))
 
 packages:
 
@@ -339,6 +345,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -641,6 +803,11 @@ packages:
 
   '@oxc-project/types@0.138.0':
     resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1835,6 +2002,11 @@ packages:
   es-module-lexer@2.3.0:
     resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1888,6 +2060,11 @@ packages:
   fs-extra@11.3.2:
     resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
     engines: {node: '>=14.14'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2212,6 +2389,16 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
@@ -2445,6 +2632,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.22.5:
+    resolution: {integrity: sha512-F7JnSfPl5ASt6LqwWyUQ3T8BwN3q0eQEbFMYa2iRWaVQmmudo0d7fRmwM4O002gsvW1bs0yBYioutsAjqLJMvQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
@@ -2703,6 +2895,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
   '@floating-ui/core@1.7.3':
     dependencies:
       '@floating-ui/utils': 0.2.10
@@ -2917,6 +3187,10 @@ snapshots:
   '@noble/hashes@1.8.0': {}
 
   '@oxc-project/types@0.138.0': {}
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@radix-ui/number@1.1.1': {}
 
@@ -3886,13 +4160,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@20.19.24)(jiti@2.6.1))':
+  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@20.19.24)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.5))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.3(@types/node@20.19.24)(jiti@2.6.1)
+      vite: 8.1.3(@types/node@20.19.24)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.5)
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -4071,6 +4345,35 @@ snapshots:
 
   es-module-lexer@2.3.0: {}
 
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
   escalade@3.2.0: {}
 
   estree-walker@3.0.3:
@@ -4107,6 +4410,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -4333,7 +4639,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  next@16.2.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next@16.2.9(@playwright/test@1.61.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -4352,6 +4658,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.9
       '@next/swc-win32-arm64-msvc': 16.2.9
       '@next/swc-win32-x64-msvc': 16.2.9
+      '@playwright/test': 1.61.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -4382,6 +4689,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-value-parser@4.2.0: {}
 
@@ -4645,6 +4960,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.22.5:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tw-animate-css@1.4.0: {}
 
   typescript@5.7.2: {}
@@ -4707,7 +5028,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@8.1.3(@types/node@20.19.24)(jiti@2.6.1):
+  vite@8.1.3(@types/node@20.19.24)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.5):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -4716,13 +5037,15 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 20.19.24
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.6.1
+      tsx: 4.22.5
 
-  vitest@4.1.9(@types/node@20.19.24)(vite@8.1.3(@types/node@20.19.24)(jiti@2.6.1)):
+  vitest@4.1.9(@types/node@20.19.24)(vite@8.1.3(@types/node@20.19.24)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.5)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@20.19.24)(jiti@2.6.1))
+      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@20.19.24)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.5))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -4739,7 +5062,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.3(@types/node@20.19.24)(jiti@2.6.1)
+      vite: 8.1.3(@types/node@20.19.24)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.5)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.24

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 allowBuilds:
   '@biomejs/biome': true
+  esbuild: true
   sharp: true
 # @anthropic-ai/sdk@0.110.0 trips pnpm's minimumReleaseAge supply-chain check (it's a
 # recent release) even though it was already a pinned dependency before this change —

--- a/frontend/supabase/config.toml
+++ b/frontend/supabase/config.toml
@@ -153,7 +153,7 @@ max_indexes = 5
 # [storage.vector.buckets.documents-openai]
 
 [auth]
-enabled = false
+enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
 site_url = "http://127.0.0.1:3000"

--- a/frontend/supabase/migrations/20260703000200_user_management_schema.sql
+++ b/frontend/supabase/migrations/20260703000200_user_management_schema.sql
@@ -1,0 +1,316 @@
+-- User Management: profiles, roles, per-module permissions
+-- Run this in the Supabase SQL Editor (supabase.com/dashboard -> SQL Editor).
+-- These tables are Supabase-native (not Django-managed).
+--
+-- Data model:
+--   profiles           <- one row per Supabase auth user (extends auth.users)
+--   roles              <- named roles, e.g. Administrator, Line Technician
+--   module_permissions <- per-role, per-module access level (view | manage)
+--   user_roles         <- many-to-many: which roles a profile holds
+--
+-- Access model:
+--   Every operational module (equipment, invoicing, training, parking,
+--   flight_operations, line_schedule, truck_sheets, fuel_farm) plus the
+--   'users' module itself is gated independently. A role grants either
+--   'view' (read-only) or 'manage' (full read/write) access per module;
+--   no row for a module means no access. A profile can hold multiple
+--   roles; access is the union (most-permissive) across all of them.
+--
+-- This improves on the house "any authenticated user can do anything"
+-- policy (see truck-sheets-schema.sql) by checking actual role grants
+-- via the has_module_access() helper below instead of auth.role().
+
+-- ============================================================
+-- 1. ROLES
+-- ============================================================
+CREATE TABLE IF NOT EXISTS roles (
+  id          BIGSERIAL PRIMARY KEY,
+  name        TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL DEFAULT '',
+  is_system   BOOLEAN NOT NULL DEFAULT FALSE, -- seeded roles; cannot be deleted
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ============================================================
+-- 2. MODULE PERMISSIONS: per-role access level per app module
+-- ============================================================
+CREATE TABLE IF NOT EXISTS module_permissions (
+  id            BIGSERIAL PRIMARY KEY,
+  role_id       BIGINT NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+  module        TEXT   NOT NULL CHECK (module IN (
+    'equipment', 'invoicing', 'training', 'parking',
+    'flight_operations', 'line_schedule', 'truck_sheets',
+    'fuel_farm', 'users'
+  )),
+  access_level  TEXT   NOT NULL CHECK (access_level IN ('view', 'manage')),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (role_id, module)
+);
+
+-- ============================================================
+-- 3. PROFILES: extends auth.users with app-facing directory data
+-- ============================================================
+CREATE TABLE IF NOT EXISTS profiles (
+  id            UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  email         TEXT NOT NULL,
+  first_name    TEXT NOT NULL DEFAULT '',
+  last_name     TEXT NOT NULL DEFAULT '',
+  phone_number  TEXT NOT NULL DEFAULT '',
+  employee_id   TEXT,
+  status        TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'disabled')),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by    UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  updated_by    UUID REFERENCES auth.users(id) ON DELETE SET NULL
+);
+
+-- ============================================================
+-- 4. USER ROLES: many-to-many, a profile can hold several roles
+-- ============================================================
+CREATE TABLE IF NOT EXISTS user_roles (
+  id          BIGSERIAL PRIMARY KEY,
+  user_id     UUID   NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  role_id     BIGINT NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+  assigned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  assigned_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  UNIQUE (user_id, role_id)
+);
+
+-- ============================================================
+-- 5. Indexes
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_module_permissions_role   ON module_permissions(role_id);
+CREATE INDEX IF NOT EXISTS idx_user_roles_user            ON user_roles(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_roles_role            ON user_roles(role_id);
+CREATE INDEX IF NOT EXISTS idx_profiles_status            ON profiles(status);
+CREATE INDEX IF NOT EXISTS idx_profiles_email             ON profiles(email);
+
+-- ============================================================
+-- 6. updated_at maintenance
+-- ============================================================
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_roles_updated_at ON roles;
+CREATE TRIGGER trg_roles_updated_at
+  BEFORE UPDATE ON roles
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_profiles_updated_at ON profiles;
+CREATE TRIGGER trg_profiles_updated_at
+  BEFORE UPDATE ON profiles
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- ============================================================
+-- 7. Auto-create a profile row whenever a Supabase auth user is
+--    created (self-registration via /register, or an admin invite
+--    via supabase.auth.admin.inviteUserByEmail).
+-- ============================================================
+CREATE OR REPLACE FUNCTION handle_new_auth_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.profiles (id, email, first_name, last_name)
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.email, ''),
+    COALESCE(NEW.raw_user_meta_data->>'first_name', ''),
+    COALESCE(NEW.raw_user_meta_data->>'last_name', '')
+  )
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION handle_new_auth_user();
+
+-- ============================================================
+-- 8. Permission helper: does the current user hold at least
+--    p_min_level access on p_module, via any of their roles?
+--    'manage' implies 'view'. SECURITY DEFINER so it can read
+--    user_roles/module_permissions regardless of the caller's
+--    own row-level access to those tables.
+-- ============================================================
+CREATE OR REPLACE FUNCTION has_module_access(p_module TEXT, p_min_level TEXT DEFAULT 'view')
+RETURNS BOOLEAN
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM user_roles ur
+    JOIN module_permissions mp ON mp.role_id = ur.role_id
+    WHERE ur.user_id = auth.uid()
+      AND mp.module = p_module
+      AND (
+        p_min_level = 'view'
+        OR mp.access_level = 'manage'
+      )
+  );
+$$;
+
+-- Convenience wrapper used throughout the RLS policies below.
+CREATE OR REPLACE FUNCTION can_manage_users()
+RETURNS BOOLEAN
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT has_module_access('users', 'manage');
+$$;
+
+-- ============================================================
+-- 9. RLS
+-- ============================================================
+ALTER TABLE roles               ENABLE ROW LEVEL SECURITY;
+ALTER TABLE module_permissions  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE profiles            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_roles          ENABLE ROW LEVEL SECURITY;
+
+-- Roles & module_permissions: any authenticated user may read them
+-- (the client needs this to resolve its own effective permissions);
+-- only users-module managers may write.
+CREATE POLICY "Authenticated users can view roles"
+  ON roles FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY "Users admins can manage roles"
+  ON roles FOR INSERT WITH CHECK (can_manage_users());
+CREATE POLICY "Users admins can update roles"
+  ON roles FOR UPDATE USING (can_manage_users());
+CREATE POLICY "Users admins can delete non-system roles"
+  ON roles FOR DELETE USING (can_manage_users() AND NOT is_system);
+
+CREATE POLICY "Authenticated users can view module permissions"
+  ON module_permissions FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY "Users admins can manage module permissions"
+  ON module_permissions FOR INSERT WITH CHECK (can_manage_users());
+CREATE POLICY "Users admins can update module permissions"
+  ON module_permissions FOR UPDATE USING (can_manage_users());
+CREATE POLICY "Users admins can delete module permissions"
+  ON module_permissions FOR DELETE USING (can_manage_users());
+
+-- Profiles: everyone can see the directory (needed for staff pickers
+-- across other modules, e.g. assigning a line tech); a user can always
+-- edit their own row; only users-module managers can edit others or
+-- delete accounts. Row inserts happen via the auth trigger (or the
+-- service-role invite route), never directly from a client.
+CREATE POLICY "Authenticated users can view profiles"
+  ON profiles FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+CREATE POLICY "Users can update their own profile"
+  ON profiles FOR UPDATE
+  USING (auth.uid() = id OR can_manage_users());
+
+CREATE POLICY "Users admins can delete profiles"
+  ON profiles FOR DELETE
+  USING (can_manage_users());
+
+-- User roles: a user can see their own role assignments (to resolve
+-- their own permissions); users-module managers can see and manage
+-- everyone's.
+CREATE POLICY "Users can view their own role assignments"
+  ON user_roles FOR SELECT
+  USING (auth.uid() = user_id OR can_manage_users());
+
+CREATE POLICY "Users admins can assign roles"
+  ON user_roles FOR INSERT WITH CHECK (can_manage_users());
+CREATE POLICY "Users admins can update role assignments"
+  ON user_roles FOR UPDATE USING (can_manage_users());
+CREATE POLICY "Users admins can remove role assignments"
+  ON user_roles FOR DELETE USING (can_manage_users());
+
+-- ============================================================
+-- 10. Seed default roles + a sensible starting permission matrix
+-- ============================================================
+INSERT INTO roles (name, description, is_system) VALUES
+  ('Administrator',   'Full access to every module, including user management.', TRUE),
+  ('Management',      'View across all operations, manage staffing-facing modules.', TRUE),
+  ('Office Staff',    'Manage front-office modules: invoicing, parking, flight ops.', TRUE),
+  ('Line Technician',  'Line-facing modules only: equipment, fuel farm, truck sheets, training.', TRUE)
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO module_permissions (role_id, module, access_level)
+SELECT r.id, m.module, 'manage'
+FROM roles r
+CROSS JOIN (VALUES
+  ('equipment'), ('invoicing'), ('training'), ('parking'),
+  ('flight_operations'), ('line_schedule'), ('truck_sheets'),
+  ('fuel_farm'), ('users')
+) AS m(module)
+WHERE r.name = 'Administrator'
+ON CONFLICT (role_id, module) DO NOTHING;
+
+INSERT INTO module_permissions (role_id, module, access_level)
+SELECT r.id, m.module, m.level
+FROM roles r
+CROSS JOIN (VALUES
+  ('equipment', 'view'), ('invoicing', 'view'), ('training', 'view'),
+  ('parking', 'view'), ('flight_operations', 'view'),
+  ('line_schedule', 'manage'), ('truck_sheets', 'view'),
+  ('fuel_farm', 'view'), ('users', 'view')
+) AS m(module, level)
+WHERE r.name = 'Management'
+ON CONFLICT (role_id, module) DO NOTHING;
+
+INSERT INTO module_permissions (role_id, module, access_level)
+SELECT r.id, m.module, m.level
+FROM roles r
+CROSS JOIN (VALUES
+  ('invoicing', 'manage'), ('parking', 'manage'),
+  ('flight_operations', 'manage'), ('line_schedule', 'view'),
+  ('equipment', 'view')
+) AS m(module, level)
+WHERE r.name = 'Office Staff'
+ON CONFLICT (role_id, module) DO NOTHING;
+
+INSERT INTO module_permissions (role_id, module, access_level)
+SELECT r.id, m.module, m.level
+FROM roles r
+CROSS JOIN (VALUES
+  ('equipment', 'manage'), ('fuel_farm', 'manage'),
+  ('truck_sheets', 'manage'), ('training', 'view'),
+  ('line_schedule', 'view')
+) AS m(module, level)
+WHERE r.name = 'Line Technician'
+ON CONFLICT (role_id, module) DO NOTHING;
+
+-- ============================================================
+-- 11. Backfill: create a profile for any auth user that predates
+--     this migration (the trigger only fires on new signups).
+-- ============================================================
+INSERT INTO profiles (id, email)
+SELECT u.id, u.email
+FROM auth.users u
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================
+-- 12. Bootstrap: grant the Administrator role to your own account
+--     so you're not locked out of /users after running this script.
+--     Replace the email below and run manually.
+-- ============================================================
+-- INSERT INTO user_roles (user_id, role_id, assigned_by)
+-- SELECT p.id, r.id, p.id
+-- FROM profiles p, roles r
+-- WHERE p.email = 'you@example.com' AND r.name = 'Administrator'
+-- ON CONFLICT (user_id, role_id) DO NOTHING;


### PR DESCRIPTION
## Summary

Adds a real-browser E2E layer (`frontend/e2e/`) that complements the repository-layer vitest suite (#25) rather than duplicating it — see the discussion in that PR's follow-up thread about why both layers are needed. This one drives the actual Next.js app in a real browser through a real Supabase Auth login (no mocks, no stubbed session) against the same local Supabase stack the repo tests use, and proves a form's "Save"/"Complete" button actually results in a row in the database — not just that it renders without error.

This targets specifically the bug class repository tests cannot catch by construction: a form that renders correctly and *looks* like it saved, but never actually calls the persistence path. The 2026-07-03 session handoff named this exact bug in the POS/invoicing ticket-entry flow.

- Enables Auth in the local Supabase stack and applies `scripts/user-management-schema.sql` as a migration (`profiles`/`roles`/`user_roles`/`module_permissions`, the `auth.users` trigger, RLS) so the real login flow works locally.
- `e2e/support/seed.ts` creates the login form's existing "Quick Dev Login" accounts (`admin@fbo.local` / `user@fbo.local`, already wired up in `components/forms/login-form.tsx`) via the Supabase Admin API and grants them roles. `e2e/global-setup.ts` logs each in through the real UI once and saves the session for reuse across specs.
- `e2e/support/db.ts` / `env.ts` mirror the vitest suite's safety posture (`tests/support/client.ts`'s `assertSafeTestTarget`): refuses to seed users or run against anything but loopback unless both a non-local URL and an explicit `E2E_ALLOW_REMOTE=yes-i-am-sure` are set.
- Two specs prove the whole pipeline end to end:
  - `equipment.e2e.ts` — create + edit, the baseline CRUD smoke test.
  - `invoicing.e2e.ts` — the digital fuel-ticket "Complete ticket" flow (the named bug). Verifies the invoice, its line item, *and* the fueling event it creates as a side effect (`truck_meter_readings`, including the `invoice_number` stamped back onto it) all land in the database.
- `e2e/README.md` documents setup, how auth/seeding works, and an honest coverage table — most forms in the app aren't covered yet. The infrastructure (seeded auth, storage-state reuse, DB verification helpers) is the expensive part and is done; extending coverage to another form is now one spec per form, not more plumbing.

`playwright.config.ts` always launches a fresh `next dev` bound to the local stack rather than reusing an already-running server, specifically so these tests (which create real records) can never end up silently running against whatever backend a stray dev server happens to be pointed at.

## Test plan

- [x] `pnpm supabase:reset` (fresh DB, all 3 migrations applied) → `pnpm e2e` → 3/3 passed
- [x] Repeated from a second clean `pnpm supabase:reset` to confirm reproducibility, not a fluke of leftover state
- [x] `pnpm test:repos` (vitest repo suite) still 16 files / 96 tests passing with Auth now enabled in the local stack
- [x] `pnpm exec tsc --noEmit` → clean