### PR TITLE
Architecture proposal: fuel dispatch ↔ truck sheets ↔ invoicing workflow (needs real review)

### DIFF
--- a/docs/architecture/fuel-invoicing-workflow.md
+++ b/docs/architecture/fuel-invoicing-workflow.md
@@ -3,6 +3,8 @@
 Status: **proposal** (schema drafted, not yet applied to the live database).
 Migration: `frontend/scripts/fuel-invoicing-workflow-schema.sql` (production, run manually via the Supabase SQL editor / `psql`) mirrored by `frontend/supabase/migrations/20260703000300_fuel_invoicing_workflow.sql` (local test stack).
 
+**Revision note:** per-tank readings were originally designed as a normalized `fuel_transaction_tank_readings` side table with a free-form `tank_position` column (to stay agnostic of aircraft type). Ted corrected this after review: he wants to run analytics later (e.g. average fuel taken by a given airline/aircraft type), which fixed columns aggregate directly in plain SQL and a normalized table would require pivoting on every query. The table was replaced with eight fixed, nullable columns on `fuel_transaction` — see "Per-tank readings" below.
+
 This resolves the long-open "fuel_transactions-to-invoice" design question (flagged since PR #15). It is modeled directly on the real paper workflow on the ramp, as described by the night-shift operator who will be scanning the sheets in — the operational nuances below are requirements, not color.
 
 ## The paper reality being modeled
@@ -47,7 +49,6 @@ No format CHECK constrains `invoice_number`: hand-written numbers are messy, and
 erDiagram
     fuel_transaction ||--o{ truck_meter_readings : "reconciled to (async, nullable)"
     fuel_transaction ||--o| invoice_line_items : "billed as ONE line (unique)"
-    fuel_transaction ||--o{ fuel_transaction_tank_readings : "optional per-tank before/after"
     truck_sheets ||--|{ truck_meter_readings : "one row per sheet line"
     truck_sheets ||--o{ scanned_documents : "original photos (pages)"
     invoices ||--|{ invoice_line_items : "fuel + services + fees"
@@ -67,6 +68,15 @@ erDiagram
         numeric gallons_requested "best-effort parse; NULL when not derivable"
         numeric gallons_delivered "as radioed in; preferred over 'gallons_pumped'"
         text progress "started | in_progress | completed"
+        numeric tank_reading_before_left "airline fuelings only, all nullable"
+        numeric tank_reading_before_right
+        numeric tank_reading_before_center "737 real tank; NULL for E175 (no center tank)"
+        numeric tank_reading_before_total "totalizer; E175's L/R/T 'T'"
+        numeric tank_reading_after_left
+        numeric tank_reading_after_right
+        numeric tank_reading_after_center
+        numeric tank_reading_after_total
+        text tank_reading_unit "lbs | gal | kg"
     }
     truck_meter_readings {
         bigint id PK
@@ -77,14 +87,6 @@ erDiagram
         numeric gallons_pumped
         numeric gallons_remaining "running inventory, as written"
         text invoice_number "as written in the last column"
-    }
-    fuel_transaction_tank_readings {
-        bigint id PK
-        bigint fuel_transaction_id FK
-        text tank_position "free-form: 737 L/C/R, E175 L/R/T, others later"
-        numeric reading_before
-        numeric reading_after
-        text reading_unit "lbs | gal | kg"
     }
     invoices {
         bigint id PK
@@ -141,7 +143,7 @@ sequenceDiagram
         LT->>LT: Fills carbon-copy slip by hand at the aircraft<br/>(incl. per-tank before/after readings)
         LT->>LT: Drops top copy in the box; writes 21483 on the truck sheet
         FD->>APP: createInvoice(number_source='paper_book') → pending pickup
-        FD->>APP: replaceTankReadings(txId, [L/C/R or L/R/T …])
+        FD->>APP: updateTankReadings(txId, { before/after left/right/center/total })
         ACC->>ACC: Midday box pickup
         ACC->>APP: markAccountingPickedUp(invoiceId)
     end
@@ -167,7 +169,11 @@ Meter numbers are **rarely entered live**. A dispatch-time `fuel_transaction` ty
 
 ## Per-tank readings (airlines only)
 
-Airline fuelings record before/after fuel per tank on the invoice slip and per-airline paperwork. The two aircraft types serviced today: **737 = L/C/R**, **E175 = L/R/T**. `fuel_transaction_tank_readings.tank_position` is free-form TEXT **by design** — a new aircraft type must never require a migration. Unit defaults to lbs (gauge readings). GA fuelings simply have no rows. (`invoice_fuel_readings` remains what it always was: a transcription of the printed DESCRIPTION block on a ticket; the new table is the transaction-side record.)
+Airline fuelings record before/after fuel per tank on the invoice slip and per-airline paperwork. The two aircraft types serviced today: **737 = L/C/R** (a real center tank) and **E175 = L/R/T** (no center tank — the "T" there is almost certainly the *totalizer* reading, not a third tank).
+
+These are **fixed, explicitly-named nullable columns directly on `fuel_transaction`** — `tank_reading_before_left/right/center/total` and `tank_reading_after_left/right/center/total`, plus one `tank_reading_unit` (default `lbs`) — rather than a normalized per-position side table. This is a deliberate revision of the original design (which used a flexible `fuel_transaction_tank_readings` table with a free-form `tank_position` column): Ted wants to run analytics later — e.g. average fuel taken by a given airline or aircraft type — and fixed columns aggregate directly with plain SQL (`AVG(tank_reading_after_total - tank_reading_before_total) ... GROUP BY ...`), where a normalized row-per-position table would need a pivot on every such query. It's also honestly a better fit for the data: this is strictly 1:1 supplemental data (one set of readings per fueling, never one-to-many), so a side table added a join for no structural reason.
+
+The tradeoff, accepted explicitly: a genuinely new aircraft layout beyond left/right/center/total (e.g. a 4-tank widebody) would need a migration to add columns, whereas the free-form table would not have. `center` and `total` simply stay `NULL` for aircraft types that don't use them (E175 fuelings: `center` always null; GA fuelings: all eight columns null). `findTankReadings`/`updateTankReadings` in `transactions.repo.ts` read/write this group as one unit. (`invoice_fuel_readings` remains what it always was: a transcription of the printed DESCRIPTION block on a ticket — a different, ticket-side record.)
 
 ## "Remaining Gallons" — per-truck running inventory
 

--- a/docs/architecture/fuel-invoicing-workflow.md
+++ b/docs/architecture/fuel-invoicing-workflow.md
@@ -1,0 +1,209 @@
+# Fuel Dispatch → Truck Sheets → Invoicing: workflow architecture
+
+Status: **proposal** (schema drafted, not yet applied to the live database).
+Migration: `frontend/scripts/fuel-invoicing-workflow-schema.sql` (production, run manually via the Supabase SQL editor / `psql`) mirrored by `frontend/supabase/migrations/20260703000300_fuel_invoicing_workflow.sql` (local test stack).
+
+This resolves the long-open "fuel_transactions-to-invoice" design question (flagged since PR #15). It is modeled directly on the real paper workflow on the ramp, as described by the night-shift operator who will be scanning the sheets in — the operational nuances below are requirements, not color.
+
+## The paper reality being modeled
+
+Two distinct physical documents exist today:
+
+**1. Truck sheet** ("2025/2026 Truck Sheet Jet A v4") — one per truck per day, the daily meter log. Columns, left to right:
+
+| Column | Notes |
+|---|---|
+| Customer | matches the invoice's *Name* field ("Life Flight", "UA 5996") |
+| Tail Number | matches across both documents |
+| Aircraft Type | e.g. B737, E175, 182 |
+| "Circle YES" | paper-only fuel-type verification mark |
+| Meter Start / Meter End | mechanical register readings; small trailing digit = tenths |
+| Gallons Pumped | should equal meter end − start |
+| Starting / Remaining Gallons | hand-kept running truck inventory (see below) |
+| Prist? Yes/No | Jet A only |
+| Line Tech initials | |
+| Invoice No. & Time | invoice number on top, time below, **written in after the invoice exists** — this is the physical correlation mechanism today |
+
+**2. Invoice slip** — carbon-copy page from a pre-printed invoice book ("MAI — Minuteman Aviation Inc"). Fields: Aircraft No., Aircraft Type, Date, Name, Address, meter reading at stop, less reading start, total gallons delivered, and a **pre-printed 5-digit invoice number in red** (e.g. "21483").
+
+Correlation between the two: truck sheet *Customer* = invoice *Name*; *tail number* matches; the line tech writes the invoice number + initials + time into the truck sheet's last column after the invoice is generated.
+
+## Two invoice-number regimes (different timing semantics)
+
+| | Dash format (`26-3330`) | 5-digit book serial (`21483`) |
+|---|---|---|
+| Who | GA / most ramp traffic | Airlines, primarily |
+| Issued by | Current accounting software, **live**: line tech radios the fueling in, front desk creates the invoice on the spot and reads the number back | Pre-printed in the paper invoice book |
+| Timing | Immediate — the number exists before the truck sheet column is filled in | Slip filled by hand at fueling time; top copy dropped in a box; **accounting collects around midday** — a real, expected batch delay |
+| Schema | `invoices.number_source = 'live'` | `invoices.number_source = 'paper_book'`; **pending pickup** = `accounting_picked_up_at IS NULL` |
+
+The pending-pickup state is deliberately **derived** (`number_source + accounting_picked_up_at`), not a new `status` enum value — the existing draft/open/paid/void lifecycle is orthogonal to whether accounting has physically collected the carbon copy. `invoices.repo.ts` exposes `inferNumberSource()`, `isPendingAccountingPickup()` and `markAccountingPickedUp()`.
+
+No format CHECK constrains `invoice_number`: hand-written numbers are messy, and rejecting them violates the resilience posture below.
+
+## Entity model
+
+```mermaid
+erDiagram
+    fuel_transaction ||--o{ truck_meter_readings : "reconciled to (async, nullable)"
+    fuel_transaction ||--o| invoice_line_items : "billed as ONE line (unique)"
+    fuel_transaction ||--o{ fuel_transaction_tank_readings : "optional per-tank before/after"
+    truck_sheets ||--|{ truck_meter_readings : "one row per sheet line"
+    truck_sheets ||--o{ scanned_documents : "original photos (pages)"
+    invoices ||--|{ invoice_line_items : "fuel + services + fees"
+    invoices ||--o{ scanned_documents : "invoice-slip scan"
+    invoice_line_items ||--o{ invoice_fuel_readings : "slip DESCRIPTION-block transcription"
+    invoice_line_items }o--o| truck_meter_readings : "provenance (which sheet row)"
+    equipment ||--o{ truck_sheets : "fuel truck"
+    customer ||--o{ invoices : "known account (nullable)"
+    flight ||--o{ fuel_transaction : "nullable"
+
+    fuel_transaction {
+        bigint id PK
+        text ticket_number
+        text tail_number
+        text customer_name "as radioed; matches sheet Customer / invoice Name"
+        text fuel_request "free-form, as written: 'T/O', '110/s Jet A+'"
+        numeric gallons_requested "best-effort parse; NULL when not derivable"
+        numeric gallons_delivered "as radioed in; preferred over 'gallons_pumped'"
+        text progress "started | in_progress | completed"
+    }
+    truck_meter_readings {
+        bigint id PK
+        bigint truck_sheet_id FK
+        bigint fuel_transaction_id FK "nullable; matched after scan; NOT unique (front+rear rows)"
+        numeric meter_start "arrives via scan, later"
+        numeric meter_end
+        numeric gallons_pumped
+        numeric gallons_remaining "running inventory, as written"
+        text invoice_number "as written in the last column"
+    }
+    fuel_transaction_tank_readings {
+        bigint id PK
+        bigint fuel_transaction_id FK
+        text tank_position "free-form: 737 L/C/R, E175 L/R/T, others later"
+        numeric reading_before
+        numeric reading_after
+        text reading_unit "lbs | gal | kg"
+    }
+    invoices {
+        bigint id PK
+        text invoice_number "no format constraint"
+        text number_source "live | paper_book"
+        timestamptz accounting_picked_up_at "NULL + paper_book = pending pickup"
+        text status "draft | open | paid | void"
+    }
+    invoice_line_items {
+        bigint id PK
+        bigint invoice_id FK
+        bigint fuel_transaction_id FK "UNIQUE where not null — no double billing"
+        bigint truck_meter_reading_id FK "kept: provenance / back-compat"
+        text item_type "fuel | service | fee | product"
+    }
+    scanned_documents {
+        bigint id PK
+        text doc_type "truck_sheet | invoice_slip"
+        text storage_path "private 'scans' bucket"
+        int page_number
+        bigint truck_sheet_id FK "nullable, linked later"
+        bigint invoice_id FK "nullable, linked later"
+    }
+```
+
+Key relationship decisions:
+
+- **`fuel_transaction` ⇄ `truck_meter_readings`**: the FK lives on the *reading* (`truck_meter_readings.fuel_transaction_id`) because the reading is the later-arriving record that gets matched back. It is intentionally **not unique** — one large fueling can legitimately span two sheet rows (front + rear register on Jet A trucks). Double-billing is prevented one level up, where it actually matters.
+- **`fuel_transaction` → `invoice_line_items`**: a fueling becomes exactly **one** line item on an invoice; other line items (GPU, oil, ramp fees, de-ice…) are added to the same invoice separately. `uq_invoice_line_items_fuel_transaction` (partial unique index) makes billing the same fueling twice a database error, extending the existing `truck_meter_reading_id` unique-index pattern. `ON DELETE RESTRICT` means a billed dispatch record can't be deleted out from under its invoice — void the invoice first (voiding clears the link and frees the uniqueness slot).
+- **`truck_meter_reading_id` on line items is kept** for provenance (which physical sheet row supplied the meter numbers) and because existing rows use it. `fuel_transaction_id` is the primary billing link going forward.
+
+## Workflow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant LT as Line tech (ramp)
+    participant FD as Front desk
+    participant APP as App (repos + Supabase)
+    participant ACC as Accounting
+
+    Note over LT,APP: A. Fueling happens (both regimes)
+    LT->>FD: Radio: customer, tail number, gallons pumped, request text
+    FD->>APP: createTransaction(tail, customer_name, fuel_request, gallons_delivered)
+    Note right of APP: No meter numbers — too much<br/>data entry over the radio.
+
+    alt GA / live regime (dash number, e.g. 26-3330)
+        FD->>ACC: Create invoice in accounting software (immediately)
+        ACC-->>FD: Invoice number 26-3330
+        FD-->>LT: Number read back over the radio
+        LT->>LT: Writes 26-3330 + initials + time on the truck sheet
+        FD->>APP: createInvoice(number_source='live',<br/>fuelLine.fuelTransactionId)
+    else Airline / paper-book regime (5-digit serial, e.g. 21483)
+        LT->>LT: Fills carbon-copy slip by hand at the aircraft<br/>(incl. per-tank before/after readings)
+        LT->>LT: Drops top copy in the box; writes 21483 on the truck sheet
+        FD->>APP: createInvoice(number_source='paper_book') → pending pickup
+        FD->>APP: replaceTankReadings(txId, [L/C/R or L/R/T …])
+        ACC->>ACC: Midday box pickup
+        ACC->>APP: markAccountingPickedUp(invoiceId)
+    end
+
+    Note over LT,APP: B. Night scan → async reconciliation (days later is fine)
+    LT->>APP: Upload truck-sheet photos (multi-page ok)
+    APP->>APP: OCR (Claude) → truck_sheets + truck_meter_readings<br/>with the real Meter Start/End numbers
+    APP->>APP: uploadScannedDocument() — original photos persisted<br/>to the private 'scans' bucket
+    APP->>APP: findMatchCandidates(tail, sheet date) per reading
+    FD->>APP: linkReadingToTransaction(readingId, txId)<br/>(backfills gallons_delivered if dispatch never got it)
+
+    Note over FD,APP: C. Billing the queue
+    FD->>APP: findUninvoicedTransactions() — completed, unbilled
+    FD->>APP: createInvoice(fuelLine.fuelTransactionId, + service lines)
+    APP->>APP: unique index rejects a second billing of the same fueling
+```
+
+Every step in section B is optional and out-of-order-tolerant — see the resilience posture below.
+
+## What is live vs. reconstructed later
+
+Meter numbers are **rarely entered live**. A dispatch-time `fuel_transaction` typically carries only: tail number, customer, `fuel_request` (free-form, exactly as written/radioed — renamed from `fuel_order_text`; the dispatch UI already labeled it "Fuel Request"), `gallons_requested` (best-effort parse of the request via `parseGallonsRequested()`; `'T/O'`, `'Fill'`, and lbs requests stay `NULL`), and `gallons_delivered` (the number radioed in — this name is preferred over "gallons pumped"; the legacy QT-era `quantity_gallons` is untouched). The real Meter Start/End arrive when the sheet is scanned, on `truck_meter_readings`, and flow back through the reconciliation link.
+
+## Per-tank readings (airlines only)
+
+Airline fuelings record before/after fuel per tank on the invoice slip and per-airline paperwork. The two aircraft types serviced today: **737 = L/C/R**, **E175 = L/R/T**. `fuel_transaction_tank_readings.tank_position` is free-form TEXT **by design** — a new aircraft type must never require a migration. Unit defaults to lbs (gauge readings). GA fuelings simply have no rows. (`invoice_fuel_readings` remains what it always was: a transcription of the printed DESCRIPTION block on a ticket; the new table is the transaction-side record.)
+
+## "Remaining Gallons" — per-truck running inventory
+
+Each sheet row's remaining gallons = previous remaining (or the day's starting gallons) − gallons pumped, with tank fills / transfers-in adding fuel back. Done by hand today, so the hand-written value is fallible. The `truck_sheet_running_totals` view derives the expected value per row (`starting_gallons` + windowed sum over the ordered rows) **beside** the as-written value, so the UI can surface discrepancies rather than silently trusting either.
+
+`~/src/minuteman` was checked per the standing copy-exactly instruction: its fuel-farm module tracks the **farm tanks** (T1–T7, LF) via inches→gallons calibration tables and has no per-truck running-total logic. Nothing to copy; the view is new logic. (Minuteman's farm-tank model was already ported here as `tank_level_readings` / `tanks.repo.ts`.)
+
+## Original scan persistence (Supabase Storage)
+
+Today only OCR-extracted JSON survives; the photos are discarded. New:
+
+- Private bucket **`scans`**, access via signed URLs only (business paperwork). RLS on `storage.objects` scoped to the bucket, house-style authenticated policy.
+- **`scanned_documents`** metadata table: `doc_type` (`truck_sheet` | `invoice_slip`), `storage_path` (`{doc_type}/{yyyy}/{mm}/{uuid}-{filename}`), `page_number` for multi-page sheets, nullable `truck_sheet_id` / `invoice_id` — a scan can exist before anyone knows what it belongs to.
+- The truck-sheet import flow (`use-truck-sheet-import.ts`) now uploads the original photos on commit, best-effort: a storage failure logs and does not roll back a successful data import (the photos still exist on the phone).
+- Repository: `frontend/repositories/scanned-documents.repo.ts`.
+
+**Invoice-slip ingestion (designed, not yet built):** slips are a second OCR layout — fields per the paper description above (Aircraft No., Aircraft Type, Date, Name, Address, meter stop / less meter start / total gallons delivered, red 5-digit serial, tank readings in the description area). A future `app/api/ocr/invoice-slip/route.ts` would mirror the truck-sheet route, then: match by the red serial → `invoices.invoice_number` (creating a `paper_book` invoice if absent), correlate to `fuel_transaction` by tail number + date, and attach the scan via `scanned_documents.invoice_id`. The schema and storage above already accept these; only the OCR route and review UI are future work.
+
+## Data-resilience posture (hard requirement)
+
+Sheets will not be scanned consistently — some days yes, some days no, for months. Therefore:
+
+- Every cross-entity link is **nullable and populated after the fact**: transaction without a reading, reading without a transaction, invoice without either — all valid indefinitely.
+- No all-or-nothing constraints; the only hard constraint is the double-billing guard, which protects money, not completeness.
+- Matching (`findMatchCandidates`) is deliberately loose — tail number + sheet date ± 1 day — and human-confirmed, not auto-committed.
+- Nothing rejects malformed hand-written values (no invoice-number format checks, `gallons_requested` never guessed).
+
+## Future phase — AI chatbot intake (explicitly out of scope now)
+
+Long-term idea: line techs "call in a fueling" by talking to a chatbot (tail number + gallons), which creates the `fuel_transaction` directly and could ask clarifying questions about ambiguous scans. **Not built now.** The only current obligation is honored: `createTransaction()` in `transactions.repo.ts` is a clean, UI-independent repository function taking exactly the radioed-in minimum — a future chatbot tool-call plugs into it (and into `findUninvoicedTransactions()` for the front-desk queue) without a rewrite.
+
+## Deliberate judgment calls / open questions for review
+
+1. **`fuel_order_text` renamed to `fuel_request`** (spec'd name; UI already said "Fuel Request"). Rename is guarded in the migration; if live rows/tooling depend on the old name elsewhere, flag it.
+2. **`customer_name` added to `fuel_transaction`** — not explicitly in the spec, but the radioed call includes the customer and the front-desk queue needs someone to bill. Cut it if dispatch should stay tail-number-only.
+3. **Reading→transaction link non-unique** (dual-register fuelings). If 1:1 should be enforced instead, add a partial unique index and split dual-register fuelings into two transactions.
+4. **`ON DELETE RESTRICT`** for billed transactions (vs. `SET NULL`): protects billing integrity at the cost of a two-step delete (void first).
+5. **Backfill**: existing invoices get `number_source` classified by number shape (5 digits = book serial), and existing non-draft book invoices get `accounting_picked_up_at = created_at` (they're in the system, so presumably collected). Existing billed `truck_meter_readings` do **not** get synthetic `fuel_transaction` rows — old lines stay on `truck_meter_reading_id` only.
+6. **Pending pickup as derived state**, not a `status` value — keeps the settlement lifecycle untouched.

--- a/frontend/app/fuel-dispatch/page.tsx
+++ b/frontend/app/fuel-dispatch/page.tsx
@@ -85,8 +85,17 @@ export default function FuelDispatchMonitorPage() {
   }
 
   const handleDelete = async (id: number) => {
-    await deleteTransaction(id)
-    toast({ title: 'Fuel order deleted' })
+    try {
+      await deleteTransaction(id)
+      toast({ title: 'Fuel order deleted' })
+    } catch (err) {
+      toast({
+        title: 'Could not delete fuel order',
+        description:
+          err instanceof Error ? err.message : 'An unexpected error occurred',
+        variant: 'destructive'
+      })
+    }
   }
 
   const handleProgress = async (id: number, progress: 'started' | 'in_progress' | 'completed') => {

--- a/frontend/components/fuel-dispatch/transaction-form-dialog.tsx
+++ b/frontend/components/fuel-dispatch/transaction-form-dialog.tsx
@@ -27,10 +27,11 @@ import { createClient } from '@/lib/supabase/client'
 import { useEquipment } from '@/hooks/use-equipment'
 import { useFlights } from '@/hooks/use-flights'
 import { useRecordEditSession } from '@/hooks/use-record-edit-session'
-import type {
-  TransactionInsert,
-  TransactionRow,
-  TransactionWithRelations
+import {
+  parseGallonsRequested,
+  type TransactionInsert,
+  type TransactionRow,
+  type TransactionWithRelations
 } from '@/repositories/transactions.repo'
 import { format } from 'date-fns'
 import { useEffect, useMemo, useState } from 'react'
@@ -43,7 +44,7 @@ interface TransactionFormData {
   tail_number: string
   fuel_type: FuelType
   fuel_truck_id: number | null
-  fuel_order_text: string
+  fuel_request: string
   quantity_gallons: string
   quantity_lbs: string
 }
@@ -66,7 +67,7 @@ const emptyForm: TransactionFormData = {
   tail_number: '',
   fuel_type: '',
   fuel_truck_id: null,
-  fuel_order_text: '',
+  fuel_request: '',
   quantity_gallons: '',
   quantity_lbs: ''
 }
@@ -111,7 +112,7 @@ export function TransactionFormDialog({
         tail_number: transaction.tail_number ?? '',
         fuel_type: transaction.fuel_type ?? '',
         fuel_truck_id: transaction.fuel_truck_id,
-        fuel_order_text: transaction.fuel_order_text ?? '',
+        fuel_request: transaction.fuel_request ?? '',
         quantity_gallons: transaction.quantity_gallons ?? '',
         quantity_lbs: transaction.quantity_lbs ?? ''
       })
@@ -147,7 +148,7 @@ export function TransactionFormDialog({
         tail_number: freshRow.tail_number ?? '',
         fuel_type: (freshRow.fuel_type as FuelType) ?? '',
         fuel_truck_id: freshRow.fuel_truck_id,
-        fuel_order_text: freshRow.fuel_order_text ?? '',
+        fuel_request: freshRow.fuel_request ?? '',
         quantity_gallons: freshRow.quantity_gallons ?? '',
         quantity_lbs: freshRow.quantity_lbs ?? ''
       })
@@ -175,7 +176,9 @@ export function TransactionFormDialog({
         tail_number: form.tail_number || null,
         fuel_type: form.fuel_type || null,
         fuel_truck_id: form.fuel_truck_id || null,
-        fuel_order_text: form.fuel_order_text || null,
+        fuel_request: form.fuel_request || null,
+        // Best-effort parse only — stays null for 'T/O', lbs requests, etc.
+        gallons_requested: parseGallonsRequested(form.fuel_request),
         quantity_gallons: gal,
         quantity_lbs: lbs,
         density: gal && lbs && density ? Number(density) : null,
@@ -325,11 +328,11 @@ export function TransactionFormDialog({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="fuel_order_text">Fuel Request</Label>
+              <Label htmlFor="fuel_request">Fuel Request</Label>
               <Input
-                id="fuel_order_text"
-                value={form.fuel_order_text}
-                onChange={(e) => setForm({ ...form, fuel_order_text: e.target.value })}
+                id="fuel_request"
+                value={form.fuel_request}
+                onChange={(e) => setForm({ ...form, fuel_request: e.target.value })}
                 placeholder='e.g. "T/O", "panel set", "110/s", "1260", "10000 lbs"'
               />
               <p className="text-xs text-muted-foreground">

--- a/frontend/hooks/use-truck-sheet-import.ts
+++ b/frontend/hooks/use-truck-sheet-import.ts
@@ -7,6 +7,7 @@ import {
   createTruckSheet,
   type TruckMeterReadingInsert,
 } from '@/repositories/truck-sheets.repo'
+import { uploadScannedDocument } from '@/repositories/scanned-documents.repo'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import type {
   ExtractedReading,
@@ -33,6 +34,8 @@ export interface ReviewSheet {
   fueler_initials: string
   page_count: number
   source_files: string[]
+  /** The original photos, in page order — persisted to Storage on import. */
+  files: File[]
   ocr_raw: unknown[]
   readings: ReviewReading[]
 }
@@ -85,6 +88,7 @@ export function mergeExtractions(
       fueler_initials: first.fueler_initials,
       page_count: group.length,
       source_files: group.map((p) => p.file.name),
+      files: group.map((p) => p.file),
       ocr_raw: group.map((p) => {
         const { raw_text: _rawText, ...extraction } = p.extraction
         return extraction
@@ -188,6 +192,29 @@ export function useTruckSheetCommit() {
             notes: r.notes || null,
           }))
         await createTruckMeterReadings(db, inserts)
+
+        // 4. Persist the original photos (private 'scans' bucket) so the
+        //    paper source outlives the OCR JSON. Best-effort by design: the
+        //    imported readings are the operationally critical data, and a
+        //    storage hiccup must not roll back a successful import — the
+        //    photos still exist on the phone and can be re-attached later.
+        for (let page = 0; page < sheet.files.length; page++) {
+          try {
+            await uploadScannedDocument(db, {
+              docType: 'truck_sheet',
+              file: sheet.files[page],
+              filename: sheet.files[page].name,
+              pageNumber: page + 1,
+              truckSheetId: sheetRow.id,
+            })
+          } catch (err) {
+            console.error(
+              `Failed to persist original scan "${sheet.files[page].name}" for truck sheet ${sheetRow.id}:`,
+              err
+            )
+          }
+        }
+
         created.push(sheetRow.id)
       }
 

--- a/frontend/lib/__tests__/db-errors.test.ts
+++ b/frontend/lib/__tests__/db-errors.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createTestClient } from '@/tests/support/client'
+import { resetDatabase } from '@/tests/support/reset'
+import {
+  ConstraintViolationError,
+  handleWriteError,
+  isPostgrestError,
+  PG_CHECK_VIOLATION,
+  PG_FOREIGN_KEY_VIOLATION,
+  PG_UNIQUE_VIOLATION
+} from '@/lib/db-errors'
+import type { PostgrestError } from '@supabase/supabase-js'
+
+const db = createTestClient()
+
+beforeEach(async () => {
+  await resetDatabase(db)
+})
+
+/**
+ * The two constraint violations this PR actually introduces (double-billing
+ * and the billed-transaction delete RESTRICT) are exercised end-to-end,
+ * against the real schema, in
+ * repositories/__tests__/fuel-invoicing-workflow.repo.test.ts. These tests
+ * cover the module's own translation logic — fallback behavior, unmapped
+ * constraints, and non-constraint passthrough — with synthetic
+ * PostgrestError-shaped objects, matching the real shape PostgREST returns.
+ */
+function fakePgError(overrides: Partial<PostgrestError> = {}): PostgrestError {
+  const base = {
+    message: 'duplicate key value violates unique constraint "some_constraint"',
+    details: 'Key (x)=(1) already exists.',
+    hint: '',
+    code: PG_UNIQUE_VIOLATION,
+    name: 'PostgrestError',
+    ...overrides
+  }
+  return {
+    ...base,
+    toJSON: () => ({ ...base })
+  }
+}
+
+describe('isPostgrestError', () => {
+  it('recognizes a real PostgrestError shape', () => {
+    expect(isPostgrestError(fakePgError())).toBe(true)
+  })
+
+  it('rejects plain Errors and non-error values', () => {
+    expect(isPostgrestError(new Error('boom'))).toBe(false)
+    expect(isPostgrestError(null)).toBe(false)
+    expect(isPostgrestError('a string')).toBe(false)
+    expect(isPostgrestError({ code: '23505' })).toBe(false) // no message
+  })
+})
+
+describe('handleWriteError', () => {
+  it('translates a known constraint into its mapped friendly message', async () => {
+    const err = fakePgError({
+      message: 'duplicate key value violates unique constraint "uq_invoice_line_items_fuel_transaction"'
+    })
+    await expect(
+      handleWriteError(db, err, { source: 'test.known' })
+    ).rejects.toMatchObject({
+      name: 'ConstraintViolationError',
+      sqlCode: PG_UNIQUE_VIOLATION,
+      constraintName: 'uq_invoice_line_items_fuel_transaction',
+      message: 'This fueling has already been added to another invoice.'
+    })
+  })
+
+  it('falls back to the default message for an unmapped constraint', async () => {
+    const err = fakePgError({
+      message: 'duplicate key value violates unique constraint "some_other_unmapped_constraint"'
+    })
+    await expect(
+      handleWriteError(db, err, { source: 'test.unmapped' })
+    ).rejects.toMatchObject({
+      name: 'ConstraintViolationError',
+      constraintName: 'some_other_unmapped_constraint',
+      message: 'This action conflicts with existing data and could not be completed.'
+    })
+  })
+
+  it('honors a caller-supplied fallback message', async () => {
+    const err = fakePgError({
+      message: 'duplicate key value violates unique constraint "some_other_unmapped_constraint"'
+    })
+    await expect(
+      handleWriteError(db, err, {
+        source: 'test.customFallback',
+        fallbackMessage: 'Custom fallback message.'
+      })
+    ).rejects.toMatchObject({ message: 'Custom fallback message.' })
+  })
+
+  it('recognizes foreign-key and check violations too, not just unique', async () => {
+    await expect(
+      handleWriteError(db, fakePgError({ code: PG_FOREIGN_KEY_VIOLATION }), {
+        source: 'test.fk'
+      })
+    ).rejects.toBeInstanceOf(ConstraintViolationError)
+
+    await expect(
+      handleWriteError(db, fakePgError({ code: PG_CHECK_VIOLATION }), {
+        source: 'test.check'
+      })
+    ).rejects.toBeInstanceOf(ConstraintViolationError)
+  })
+
+  it('passes through unrelated Postgres errors unchanged (not a constraint violation)', async () => {
+    const notNullErr = fakePgError({
+      code: '23502',
+      message: 'null value in column "x" violates not-null constraint'
+    })
+    await expect(
+      handleWriteError(db, notNullErr, { source: 'test.notNull' })
+    ).rejects.toBe(notNullErr)
+  })
+
+  it('logs every handled error to app_error_log, categorized correctly', async () => {
+    await handleWriteError(
+      db,
+      fakePgError({
+        message: 'duplicate key value violates unique constraint "uq_invoice_line_items_fuel_transaction"'
+      }),
+      { source: 'test.logged', context: { invoice_id: 99 } }
+    ).catch(() => {})
+
+    await handleWriteError(db, fakePgError({ code: '23502', message: 'not null violation' }), {
+      source: 'test.loggedNonConstraint'
+    }).catch(() => {})
+
+    const { data } = await db.from('app_error_log').select('*').order('id')
+    expect(data).toHaveLength(2)
+    expect(data?.[0]).toMatchObject({
+      category: 'db_constraint',
+      error_code: 'uq_invoice_line_items_fuel_transaction',
+      source: 'test.logged'
+    })
+    expect(data?.[0].context).toEqual({ invoice_id: 99 })
+    expect(data?.[1]).toMatchObject({
+      category: 'db_query',
+      error_code: '23502',
+      source: 'test.loggedNonConstraint'
+    })
+  })
+})

--- a/frontend/lib/__tests__/error-logging.test.ts
+++ b/frontend/lib/__tests__/error-logging.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createTestClient } from '@/tests/support/client'
+import { resetDatabase } from '@/tests/support/reset'
+import { logAppError } from '@/lib/error-logging'
+
+const db = createTestClient()
+
+beforeEach(async () => {
+  await resetDatabase(db)
+})
+
+describe('error-logging', () => {
+  it('persists a full structured entry', async () => {
+    await logAppError(db, {
+      category: 'db_constraint',
+      code: 'some_constraint',
+      message: 'Friendly message',
+      detail: '[23505] raw postgres detail',
+      context: { invoice_id: 5, fuel_transaction_id: 12 },
+      source: 'test.someFunction'
+    })
+
+    const { data } = await db.from('app_error_log').select('*')
+    expect(data).toHaveLength(1)
+    expect(data?.[0]).toMatchObject({
+      category: 'db_constraint',
+      error_code: 'some_constraint',
+      message: 'Friendly message',
+      detail: '[23505] raw postgres detail',
+      source: 'test.someFunction'
+    })
+    expect(data?.[0].context).toEqual({ invoice_id: 5, fuel_transaction_id: 12 })
+    expect(data?.[0].occurred_at).toBeTruthy()
+    // service-role test client has no user session — auto-derived userId is null
+    expect(data?.[0].user_id).toBeNull()
+  })
+
+  it('uses an explicitly passed userId over auto-derivation', async () => {
+    const fakeUserId = '00000000-0000-0000-0000-000000000001'
+    await logAppError(db, {
+      category: 'unknown',
+      code: 'x',
+      message: 'x',
+      userId: fakeUserId
+    })
+    const { data } = await db.from('app_error_log').select('user_id')
+    expect(data?.[0].user_id).toBe(fakeUserId)
+  })
+
+  it('never throws even when the persistence write itself fails', async () => {
+    // an invalid UUID for user_id makes the insert fail at the DB level;
+    // logAppError must swallow that (and only report it to the console),
+    // never propagate it to the caller.
+    await expect(
+      logAppError(db, {
+        category: 'unknown',
+        code: 'test',
+        message: 'test message',
+        userId: 'not-a-valid-uuid'
+      })
+    ).resolves.toBeUndefined()
+
+    const { data } = await db.from('app_error_log').select('*')
+    expect(data).toHaveLength(0) // the failed insert did not persist anything
+  })
+
+  it('defaults context and detail to null when omitted', async () => {
+    await logAppError(db, {
+      category: 'validation',
+      code: 'missing_field',
+      message: 'Something was missing'
+    })
+    const { data } = await db.from('app_error_log').select('*').single()
+    expect(data?.detail).toBeNull()
+    expect(data?.context).toBeNull()
+    expect(data?.source).toBeNull()
+  })
+})

--- a/frontend/lib/db-errors.ts
+++ b/frontend/lib/db-errors.ts
@@ -1,0 +1,131 @@
+import type { Database } from '@/types/database'
+import type { PostgrestError, SupabaseClient } from '@supabase/supabase-js'
+import { type ErrorCategory, logAppError } from './error-logging'
+
+/** Postgres SQLSTATE codes for the constraint violations PostgREST passes through as-is. */
+export const PG_UNIQUE_VIOLATION = '23505'
+export const PG_FOREIGN_KEY_VIOLATION = '23503'
+export const PG_CHECK_VIOLATION = '23514'
+
+const CONSTRAINT_VIOLATION_CODES: ReadonlySet<string> = new Set([
+  PG_UNIQUE_VIOLATION,
+  PG_FOREIGN_KEY_VIOLATION,
+  PG_CHECK_VIOLATION
+])
+
+export function isPostgrestError(err: unknown): err is PostgrestError {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    'message' in err &&
+    typeof (err as { message: unknown }).message === 'string'
+  )
+}
+
+function pgConstraintName(err: PostgrestError): string | null {
+  const match = err.message.match(/constraint "([^"]+)"/)
+  return match ? match[1] : null
+}
+
+/**
+ * Thrown when a repository write is rejected by a database constraint
+ * (unique / foreign key / check) that the caller should present to the
+ * user as a clear, actionable message instead of a raw Postgres error
+ * string. `.message` is safe to show a user; the original PostgrestError is
+ * kept on `.cause` for anything that wants the raw detail. Mirrors the
+ * existing ConcurrencyConflictError pattern (lib/concurrency.ts) — catch
+ * this specifically rather than treating it as a generic write failure.
+ */
+export class ConstraintViolationError extends Error {
+  readonly sqlCode: string
+  readonly constraintName: string | null
+
+  constructor(
+    message: string,
+    sqlCode: string,
+    constraintName: string | null,
+    options?: ErrorOptions
+  ) {
+    super(message, options)
+    this.name = 'ConstraintViolationError'
+    this.sqlCode = sqlCode
+    this.constraintName = constraintName
+  }
+}
+
+/**
+ * Friendly messages for constraints a normal user action could plausibly
+ * hit. Add an entry here whenever a new UNIQUE/FK/CHECK constraint is
+ * introduced that isn't purely a programmer-error case — see
+ * docs/architecture/fuel-invoicing-workflow.md for where these two come
+ * from (the fuel_transaction ↔ invoicing linkage).
+ */
+const FRIENDLY_CONSTRAINT_MESSAGES: Record<string, string> = {
+  uq_invoice_line_items_fuel_transaction:
+    'This fueling has already been added to another invoice.',
+  uq_invoice_line_items_meter_reading:
+    'This fueling event has already been added to another invoice.',
+  invoice_line_items_fuel_transaction_id_fkey:
+    'This fueling has already been billed to an invoice — void the invoice before deleting it.'
+}
+
+const DEFAULT_FALLBACK_MESSAGE =
+  'This action conflicts with existing data and could not be completed.'
+
+function translateConstraintViolation(
+  err: PostgrestError,
+  fallback: string
+): ConstraintViolationError | null {
+  if (!CONSTRAINT_VIOLATION_CODES.has(err.code)) return null
+  const constraintName = pgConstraintName(err)
+  const message =
+    (constraintName && FRIENDLY_CONSTRAINT_MESSAGES[constraintName]) ||
+    fallback
+  return new ConstraintViolationError(message, err.code, constraintName, {
+    cause: err
+  })
+}
+
+/**
+ * Handles a failed repository write: logs the raw Postgres error (the first
+ * real usage of lib/error-logging.ts) and throws a user-safe error —
+ * ConstraintViolationError with a friendly `.message` when the failure is a
+ * known constraint violation, otherwise the original PostgrestError
+ * unchanged (so unrelated failures aren't silently mislabeled).
+ *
+ * Always throws; callers should invoke this from inside an `if (error) { ... }`
+ * branch right after a Supabase write, e.g.:
+ *
+ *   if (error) {
+ *     await handleWriteError(db, error, { source: 'x.repo.y', context: { id } })
+ *   }
+ */
+export async function handleWriteError(
+  db: SupabaseClient<Database>,
+  err: PostgrestError,
+  opts: {
+    source: string
+    context?: Record<string, unknown> | null
+    fallbackMessage?: string
+  }
+): Promise<never> {
+  const translated = translateConstraintViolation(
+    err,
+    opts.fallbackMessage ?? DEFAULT_FALLBACK_MESSAGE
+  )
+  const category: ErrorCategory = translated ? 'db_constraint' : 'db_query'
+
+  await logAppError(db, {
+    category,
+    code: translated?.constraintName ?? err.code ?? 'unknown',
+    message: translated?.message ?? err.message,
+    detail: `[${err.code}] ${err.message}${err.details ? ` — ${err.details}` : ''}${
+      err.hint ? ` (hint: ${err.hint})` : ''
+    }`,
+    context: opts.context ?? null,
+    source: opts.source
+  })
+
+  throw translated ?? err
+}

--- a/frontend/lib/error-logging.ts
+++ b/frontend/lib/error-logging.ts
@@ -1,0 +1,116 @@
+import type { Database, Tables, TablesInsert } from '@/types/database'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * A small, reusable observability primitive — NOT specific to any one
+ * feature (invoicing happens to be its first caller; see lib/db-errors.ts).
+ *
+ * Why this exists: deployment is Docker on a VPS with no log aggregation
+ * set up. Container stdout is ephemeral and not queryable after the
+ * container recycles, so when a user reports "something went wrong" there
+ * is currently no way to reconstruct what actually happened. app_error_log
+ * (frontend/scripts/error-logging-schema.sql) is the durable record.
+ *
+ * Entries are deliberately structured/queryable — timestamp, category,
+ * code, entity ids, user id — so a human (or, later, a support chatbot;
+ * see docs/architecture/fuel-invoicing-workflow.md's future-phase note,
+ * not built now) can reasonably ask "what happened around timestamp X for
+ * user Y?" without grepping unstructured text.
+ */
+
+export type AppErrorLogRow = Tables<'app_error_log'>
+
+/**
+ * Coarse, stable bucket for grouping/querying — kept small on purpose.
+ * Specifics belong in `code` and `source`, not in a growing category list.
+ */
+export type ErrorCategory =
+  | 'db_constraint'
+  | 'db_query'
+  | 'network'
+  | 'validation'
+  | 'auth'
+  | 'storage'
+  | 'unknown'
+
+export interface AppErrorLogInput {
+  category: ErrorCategory
+  /**
+   * Short, stable machine code: a Postgres constraint name
+   * ('uq_invoice_line_items_fuel_transaction'), a SQLSTATE ('23503'), or an
+   * app-defined code for non-DB errors. Not shown to end users.
+   */
+  code: string
+  /** Human-readable summary. May be the same friendly message shown to a user, but isn't required to be. */
+  message: string
+  /**
+   * Full technical detail — raw error message, stack trace, Postgres
+   * `details`/`hint`. NEVER surface this to end users; it exists purely so
+   * a developer (or future support tool) can reconstruct what happened.
+   */
+  detail?: string | null
+  /** Relevant entity ids, e.g. `{ invoice_id: 5, fuel_transaction_id: 12 }`. */
+  context?: Record<string, unknown> | null
+  /**
+   * Acting user's id. When omitted, logAppError looks it up from
+   * `db.auth.getUser()` — pass explicitly only if you already have it, or
+   * if `db` is a service-role client with no user session to look up.
+   */
+  userId?: string | null
+  /** Where in the code this was raised, e.g. `'invoices.repo.createInvoice'`. */
+  source?: string | null
+}
+
+/**
+ * Persists a structured error entry to `app_error_log` and always echoes it
+ * to the console first, so local/dev visibility never depends on the
+ * database write succeeding.
+ *
+ * Never throws: a logging failure must never break the caller's actual
+ * error handling. Failures here are only ever reported to the console.
+ */
+export async function logAppError(
+  db: SupabaseClient<Database>,
+  input: AppErrorLogInput
+): Promise<void> {
+  const occurredAt = new Date().toISOString()
+
+  console.error('[app-error]', {
+    occurred_at: occurredAt,
+    category: input.category,
+    code: input.code,
+    message: input.message,
+    detail: input.detail ?? undefined,
+    context: input.context ?? undefined,
+    source: input.source ?? undefined
+  })
+
+  try {
+    let userId = input.userId ?? null
+    if (userId == null) {
+      try {
+        const { data } = await db.auth.getUser()
+        userId = data.user?.id ?? null
+      } catch {
+        userId = null // e.g. a service-role client with no session — expected, not an error
+      }
+    }
+
+    const entry: TablesInsert<'app_error_log'> = {
+      occurred_at: occurredAt,
+      category: input.category,
+      error_code: input.code,
+      message: input.message,
+      detail: input.detail ?? null,
+      context: input.context ?? null,
+      user_id: userId,
+      source: input.source ?? null
+    }
+    const { error } = await db.from('app_error_log').insert(entry)
+    if (error) {
+      console.error('[app-error] failed to persist log entry:', error)
+    }
+  } catch (err) {
+    console.error('[app-error] failed to persist log entry (threw):', err)
+  }
+}

--- a/frontend/repositories/__tests__/fuel-invoicing-workflow.repo.test.ts
+++ b/frontend/repositories/__tests__/fuel-invoicing-workflow.repo.test.ts
@@ -1,0 +1,428 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createTestClient } from '@/tests/support/client'
+import { resetDatabase } from '@/tests/support/reset'
+import { makeEquipment } from '@/tests/support/factories'
+import {
+  createTransaction,
+  deleteTransaction,
+  findMatchCandidates,
+  findTankReadings,
+  findUninvoicedTransactions,
+  linkReadingToTransaction,
+  parseGallonsRequested,
+  replaceTankReadings,
+  unlinkReading,
+} from '@/repositories/transactions.repo'
+import {
+  createTruckMeterReadings,
+  createTruckSheet,
+  type TruckMeterReadingRow,
+} from '@/repositories/truck-sheets.repo'
+import {
+  createInvoice,
+  inferNumberSource,
+  isPendingAccountingPickup,
+  markAccountingPickedUp,
+  voidInvoice,
+  type NewInvoiceInput,
+} from '@/repositories/invoices.repo'
+import {
+  deleteScannedDocument,
+  findScansForTruckSheet,
+  findUnlinkedScans,
+  getScanSignedUrl,
+  linkScanToTruckSheet,
+  uploadScannedDocument,
+} from '@/repositories/scanned-documents.repo'
+
+const db = createTestClient()
+
+beforeEach(async () => {
+  await resetDatabase(db)
+})
+
+const TODAY = '2026-07-03'
+
+async function makeSheetWithReading(
+  overrides: Partial<Parameters<typeof createTruckMeterReadings>[1][number]> = {}
+): Promise<{ sheetId: number; reading: TruckMeterReadingRow }> {
+  const truck = await makeEquipment(db, { equipment_type: 'fuel_truck' })
+  const sheet = await createTruckSheet(db, {
+    sheet_date: TODAY,
+    fuel_truck_id: truck.id,
+    truck_number: '5282',
+    fuel_type: 'jet_a',
+    starting_gallons: 5000,
+  })
+  const [reading] = await createTruckMeterReadings(db, [
+    {
+      truck_sheet_id: sheet.id,
+      line_number: 1,
+      reading_type: 'fueling',
+      customer: 'Life Flight',
+      tail_number: 'N116FE',
+      meter_start: 108413.4,
+      meter_end: 108447.6,
+      gallons_pumped: 34.2,
+      ...overrides,
+    },
+  ])
+  return { sheetId: sheet.id, reading }
+}
+
+function invoiceInput(overrides: Partial<NewInvoiceInput['header']> = {}): NewInvoiceInput {
+  return {
+    header: {
+      invoiceNumber: `26-${Math.floor(Math.random() * 10_000)}`,
+      invoiceDate: TODAY,
+      customerId: null,
+      customerName: 'Life Flight',
+      station: null,
+      tailNumber: 'N116FE',
+      aircraftType: null,
+      flightId: null,
+      paymentMethod: 'cash',
+      checkNumber: null,
+      salesmanInitials: 'TT',
+      notes: null,
+      ...overrides,
+    },
+    fuelLine: null,
+    serviceLines: [],
+    finalize: true,
+  }
+}
+
+describe('parseGallonsRequested', () => {
+  it('parses plain and decorated gallon requests', () => {
+    expect(parseGallonsRequested('300')).toBe(300)
+    expect(parseGallonsRequested('1,249')).toBe(1249)
+    expect(parseGallonsRequested('110/s Jet A+')).toBe(110)
+  })
+
+  it('returns null for anything that is not clearly gallons', () => {
+    expect(parseGallonsRequested('T/O')).toBeNull()
+    expect(parseGallonsRequested('Fill')).toBeNull()
+    expect(parseGallonsRequested('2700 lbs')).toBeNull()
+    expect(parseGallonsRequested('2700lbs')).toBeNull()
+    expect(parseGallonsRequested(null)).toBeNull()
+    expect(parseGallonsRequested('')).toBeNull()
+  })
+})
+
+describe('dispatch ↔ truck-sheet reconciliation', () => {
+  it('accepts the radioed-in minimum: no meter numbers at creation', async () => {
+    const tx = await createTransaction(db, {
+      ticket_number: 'RADIO-1',
+      tail_number: 'N116FE',
+      customer_name: 'Life Flight',
+      fuel_request: 'T/O',
+      gallons_delivered: 34.2,
+    })
+    expect(tx.fuel_request).toBe('T/O')
+    expect(tx.gallons_requested).toBeNull()
+    expect(Number(tx.gallons_delivered)).toBeCloseTo(34.2)
+  })
+
+  it('finds match candidates by tail number around the sheet date', async () => {
+    const tx = await createTransaction(db, {
+      ticket_number: 'MATCH-1',
+      tail_number: 'N116FE',
+    })
+    await createTransaction(db, { ticket_number: 'OTHER', tail_number: 'N999ZZ' })
+
+    const candidates = await findMatchCandidates(db, {
+      tailNumber: 'n116fe', // case-insensitive
+      sheetDate: TODAY,
+    })
+    expect(candidates.map((c) => c.id)).toEqual([tx.id])
+    expect(candidates[0].truck_meter_readings).toEqual([])
+  })
+
+  it('returns no candidates without a tail number to match on', async () => {
+    await createTransaction(db, { ticket_number: 'X', tail_number: 'N116FE' })
+    expect(await findMatchCandidates(db, { tailNumber: null, sheetDate: TODAY })).toEqual([])
+    expect(await findMatchCandidates(db, { tailNumber: '  ', sheetDate: TODAY })).toEqual([])
+  })
+
+  it('links a scanned reading to its transaction and backfills gallons_delivered', async () => {
+    const tx = await createTransaction(db, {
+      ticket_number: 'LINK-1',
+      tail_number: 'N116FE',
+      fuel_request: 'T/O', // no gallons radioed in
+    })
+    const { reading } = await makeSheetWithReading()
+
+    await linkReadingToTransaction(db, reading.id, tx.id)
+
+    const { data: linked } = await db
+      .from('truck_meter_readings')
+      .select('fuel_transaction_id')
+      .eq('id', reading.id)
+      .single()
+    expect(linked?.fuel_transaction_id).toBe(tx.id)
+
+    const { data: refreshed } = await db
+      .from('fuel_transaction')
+      .select('gallons_delivered')
+      .eq('id', tx.id)
+      .single()
+    expect(Number(refreshed?.gallons_delivered)).toBeCloseTo(34.2)
+  })
+
+  it('does not overwrite gallons_delivered that dispatch already had', async () => {
+    const tx = await createTransaction(db, {
+      ticket_number: 'LINK-2',
+      tail_number: 'N116FE',
+      gallons_delivered: 35,
+    })
+    const { reading } = await makeSheetWithReading()
+
+    await linkReadingToTransaction(db, reading.id, tx.id)
+
+    const { data: refreshed } = await db
+      .from('fuel_transaction')
+      .select('gallons_delivered')
+      .eq('id', tx.id)
+      .single()
+    expect(Number(refreshed?.gallons_delivered)).toBe(35)
+  })
+
+  it('allows one transaction to span multiple sheet rows (front + rear register)', async () => {
+    const tx = await createTransaction(db, { ticket_number: 'DUAL', tail_number: 'N116FE' })
+    const { sheetId, reading: front } = await makeSheetWithReading({ meter: 'front' })
+    const [rear] = await createTruckMeterReadings(db, [
+      {
+        truck_sheet_id: sheetId,
+        line_number: 2,
+        reading_type: 'fueling',
+        tail_number: 'N116FE',
+        meter: 'rear',
+        gallons_pumped: 1200,
+      },
+    ])
+
+    await linkReadingToTransaction(db, front.id, tx.id)
+    await linkReadingToTransaction(db, rear.id, tx.id)
+
+    const candidates = await findMatchCandidates(db, { tailNumber: 'N116FE', sheetDate: TODAY })
+    expect(candidates[0].truck_meter_readings).toHaveLength(2)
+
+    await unlinkReading(db, front.id)
+    const after = await findMatchCandidates(db, { tailNumber: 'N116FE', sheetDate: TODAY })
+    expect(after[0].truck_meter_readings).toHaveLength(1)
+  })
+})
+
+describe('per-tank readings (airline fuelings)', () => {
+  it('stores flexible tank positions — E175 L/R/T here — and replaces them wholesale', async () => {
+    const tx = await createTransaction(db, { ticket_number: 'E175-1', tail_number: 'N123UA' })
+
+    await replaceTankReadings(db, tx.id, [
+      { tank_position: 'L', reading_before: 3930, reading_after: 7950 },
+      { tank_position: 'R', reading_before: 4040, reading_after: 7950 },
+      { tank_position: 'T', reading_before: 7970, reading_after: 15900 },
+    ])
+
+    let readings = await findTankReadings(db, tx.id)
+    expect(readings.map((r) => r.tank_position)).toEqual(['L', 'R', 'T'])
+    expect(readings.every((r) => r.reading_unit === 'lbs')).toBe(true)
+
+    // 737 layout is just different position strings — no schema knowledge of types
+    await replaceTankReadings(db, tx.id, [
+      { tank_position: 'L', reading_before: 5000, reading_after: 9000 },
+      { tank_position: 'C', reading_before: 0, reading_after: 4000 },
+      { tank_position: 'R', reading_before: 5000, reading_after: 9000 },
+    ])
+    readings = await findTankReadings(db, tx.id)
+    expect(readings.map((r) => r.tank_position)).toEqual(['C', 'L', 'R'])
+
+    await replaceTankReadings(db, tx.id, [])
+    expect(await findTankReadings(db, tx.id)).toEqual([])
+  })
+})
+
+describe('billing a fuel_transaction', () => {
+  async function billTransaction(txId: number, overrides: Partial<NewInvoiceInput['header']> = {}) {
+    const input = invoiceInput(overrides)
+    input.fuelLine = {
+      fuelTransactionId: txId,
+      fuelType: 'jet_a',
+      quantityGallons: 34.2,
+      pricePerGallon: 6.75,
+      density: null,
+      requestedAmount: null,
+      serviceTime: null,
+      readings: [],
+    }
+    return createInvoice(db, input)
+  }
+
+  it('a completed transaction is uninvoiced until billed, then leaves the queue', async () => {
+    const tx = await createTransaction(db, {
+      ticket_number: 'QUEUE-1',
+      tail_number: 'N116FE',
+      progress: 'completed',
+    })
+    await createTransaction(db, { ticket_number: 'STILL-OPEN', progress: 'started' })
+
+    let queue = await findUninvoicedTransactions(db)
+    expect(queue.map((t) => t.id)).toEqual([tx.id]) // only completed, unbilled
+
+    const invoice = await billTransaction(tx.id)
+    expect(invoice.line_items[0].fuel_transaction_id).toBe(tx.id)
+    expect(invoice.line_items[0].fuel_transaction?.ticket_number).toBe('QUEUE-1')
+
+    queue = await findUninvoicedTransactions(db)
+    expect(queue).toEqual([])
+  })
+
+  it('refuses to bill the same fuel_transaction twice (double-billing guard)', async () => {
+    const tx = await createTransaction(db, {
+      ticket_number: 'ONCE',
+      tail_number: 'N116FE',
+      progress: 'completed',
+    })
+    await billTransaction(tx.id)
+    await expect(billTransaction(tx.id)).rejects.toMatchObject({ code: '23505' })
+  })
+
+  it('voiding the invoice releases the transaction for rebilling', async () => {
+    const tx = await createTransaction(db, {
+      ticket_number: 'REBILL',
+      tail_number: 'N116FE',
+      progress: 'completed',
+    })
+    const invoice = await billTransaction(tx.id)
+
+    await voidInvoice(db, invoice)
+    const rebilled = await billTransaction(tx.id, {
+      invoiceNumber: `26-${Math.floor(Math.random() * 10_000)}`,
+    })
+    expect(rebilled.line_items[0].fuel_transaction_id).toBe(tx.id)
+  })
+
+  it('blocks deleting a billed transaction (void the invoice first)', async () => {
+    const tx = await createTransaction(db, {
+      ticket_number: 'RESTRICT',
+      tail_number: 'N116FE',
+      progress: 'completed',
+    })
+    const invoice = await billTransaction(tx.id)
+
+    await expect(deleteTransaction(db, tx.id)).rejects.toMatchObject({ code: '23503' })
+
+    await voidInvoice(db, invoice)
+    await deleteTransaction(db, tx.id) // now allowed
+  })
+
+  it('billing a reconciled sheet row inherits its linked transaction', async () => {
+    const tx = await createTransaction(db, {
+      ticket_number: 'INHERIT',
+      tail_number: 'N116FE',
+      progress: 'completed',
+    })
+    const { reading } = await makeSheetWithReading()
+    await linkReadingToTransaction(db, reading.id, tx.id)
+
+    const input = invoiceInput()
+    input.fuelLine = {
+      truckMeterReadingId: reading.id,
+      fuelType: 'jet_a',
+      quantityGallons: 34.2,
+      pricePerGallon: 6.75,
+      density: null,
+      requestedAmount: null,
+      serviceTime: null,
+      readings: [],
+    }
+    const invoice = await createInvoice(db, input)
+    expect(invoice.line_items[0].fuel_transaction_id).toBe(tx.id)
+    expect(invoice.line_items[0].truck_meter_reading_id).toBe(reading.id)
+  })
+})
+
+describe('invoice-number regimes', () => {
+  it('classifies dash numbers as live and 5-digit book serials as paper_book', () => {
+    expect(inferNumberSource('26-3330')).toBe('live')
+    expect(inferNumberSource('21483')).toBe('paper_book')
+    expect(inferNumberSource(' 21483 ')).toBe('paper_book')
+    expect(inferNumberSource('214835')).toBe('live') // 6 digits: not a book serial
+  })
+
+  it('a paper-book invoice is pending pickup until accounting collects it', async () => {
+    const invoice = await createInvoice(db, invoiceInput({
+      invoiceNumber: '21483',
+      paymentMethod: 'eom', // airline account billing
+    }))
+    expect(invoice.number_source).toBe('paper_book')
+    expect(isPendingAccountingPickup(invoice)).toBe(true)
+
+    const picked = await markAccountingPickedUp(db, invoice.id)
+    expect(picked.accounting_picked_up_at).not.toBeNull()
+    expect(isPendingAccountingPickup(picked)).toBe(false)
+  })
+
+  it('a live dash-format invoice is never pending pickup', async () => {
+    const invoice = await createInvoice(db, invoiceInput({ invoiceNumber: '26-3330' }))
+    expect(invoice.number_source).toBe('live')
+    expect(isPendingAccountingPickup(invoice)).toBe(false)
+  })
+})
+
+describe('scanned_documents (original scan persistence)', () => {
+  function fakePhoto(contents: string): Blob {
+    return new Blob([contents], { type: 'image/jpeg' })
+  }
+
+  it('uploads, lists, signs, and deletes truck-sheet scans', async () => {
+    const { sheetId } = await makeSheetWithReading()
+
+    const page1 = await uploadScannedDocument(db, {
+      docType: 'truck_sheet',
+      file: fakePhoto('page one'),
+      filename: 'IMG_0001.jpg',
+      pageNumber: 1,
+      truckSheetId: sheetId,
+    })
+    await uploadScannedDocument(db, {
+      docType: 'truck_sheet',
+      file: fakePhoto('page two'),
+      filename: 'IMG_0002.jpg',
+      pageNumber: 2,
+      truckSheetId: sheetId,
+    })
+
+    const scans = await findScansForTruckSheet(db, sheetId)
+    expect(scans.map((s) => s.page_number)).toEqual([1, 2])
+    expect(scans[0].doc_type).toBe('truck_sheet')
+    expect(scans[0].storage_path).toMatch(/^truck_sheet\/\d{4}\/\d{2}\//)
+
+    const url = await getScanSignedUrl(db, page1)
+    expect(url).toContain(page1.storage_path.split('/').pop() as string)
+
+    for (const scan of scans) {
+      await deleteScannedDocument(db, scan)
+    }
+    expect(await findScansForTruckSheet(db, sheetId)).toEqual([])
+  })
+
+  it('supports scans uploaded before anyone knows what they belong to', async () => {
+    const scan = await uploadScannedDocument(db, {
+      docType: 'invoice_slip',
+      file: fakePhoto('carbon copy 21483'),
+      filename: 'slip.jpg',
+    })
+    expect(scan.truck_sheet_id).toBeNull()
+    expect(scan.invoice_id).toBeNull()
+
+    const unlinked = await findUnlinkedScans(db, 'invoice_slip')
+    expect(unlinked.map((s) => s.id)).toEqual([scan.id])
+
+    const { sheetId } = await makeSheetWithReading()
+    await linkScanToTruckSheet(db, scan.id, sheetId, 1)
+    expect(await findUnlinkedScans(db)).toEqual([])
+
+    await deleteScannedDocument(db, scan)
+  })
+})

--- a/frontend/repositories/__tests__/fuel-invoicing-workflow.repo.test.ts
+++ b/frontend/repositories/__tests__/fuel-invoicing-workflow.repo.test.ts
@@ -10,7 +10,7 @@ import {
   findUninvoicedTransactions,
   linkReadingToTransaction,
   parseGallonsRequested,
-  replaceTankReadings,
+  updateTankReadings,
   unlinkReading,
 } from '@/repositories/transactions.repo'
 import {
@@ -214,31 +214,86 @@ describe('dispatch ↔ truck-sheet reconciliation', () => {
   })
 })
 
-describe('per-tank readings (airline fuelings)', () => {
-  it('stores flexible tank positions — E175 L/R/T here — and replaces them wholesale', async () => {
+describe('per-tank readings (airline fuelings, fixed columns)', () => {
+  it('is null until set — GA transactions never touch these columns', async () => {
+    const tx = await createTransaction(db, { ticket_number: 'GA-1', tail_number: 'N1GA' })
+    expect(await findTankReadings(db, tx.id)).toBeNull()
+  })
+
+  it('E175 (L/R/T): T is the totalizer, not a center tank — center stays null', async () => {
     const tx = await createTransaction(db, { ticket_number: 'E175-1', tail_number: 'N123UA' })
 
-    await replaceTankReadings(db, tx.id, [
-      { tank_position: 'L', reading_before: 3930, reading_after: 7950 },
-      { tank_position: 'R', reading_before: 4040, reading_after: 7950 },
-      { tank_position: 'T', reading_before: 7970, reading_after: 15900 },
-    ])
+    await updateTankReadings(db, tx.id, {
+      before_left: 3930,
+      before_right: 4040,
+      before_center: null,
+      before_total: 7970,
+      after_left: 7950,
+      after_right: 7950,
+      after_center: null,
+      after_total: 15900,
+    })
 
-    let readings = await findTankReadings(db, tx.id)
-    expect(readings.map((r) => r.tank_position)).toEqual(['L', 'R', 'T'])
-    expect(readings.every((r) => r.reading_unit === 'lbs')).toBe(true)
+    const readings = await findTankReadings(db, tx.id)
+    expect(readings).toEqual({
+      before_left: 3930,
+      before_right: 4040,
+      before_center: null,
+      before_total: 7970,
+      after_left: 7950,
+      after_right: 7950,
+      after_center: null,
+      after_total: 15900,
+      unit: 'lbs',
+    })
+  })
 
-    // 737 layout is just different position strings — no schema knowledge of types
-    await replaceTankReadings(db, tx.id, [
-      { tank_position: 'L', reading_before: 5000, reading_after: 9000 },
-      { tank_position: 'C', reading_before: 0, reading_after: 4000 },
-      { tank_position: 'R', reading_before: 5000, reading_after: 9000 },
-    ])
-    readings = await findTankReadings(db, tx.id)
-    expect(readings.map((r) => r.tank_position)).toEqual(['C', 'L', 'R'])
+  it('737 (L/C/R): center is a real tank', async () => {
+    const tx = await createTransaction(db, { ticket_number: '737-1', tail_number: 'N737X' })
 
-    await replaceTankReadings(db, tx.id, [])
-    expect(await findTankReadings(db, tx.id)).toEqual([])
+    await updateTankReadings(db, tx.id, {
+      before_left: 5000,
+      before_right: 5000,
+      before_center: 0,
+      before_total: null,
+      after_left: 9000,
+      after_right: 9000,
+      after_center: 4000,
+      after_total: null,
+      unit: 'lbs',
+    })
+
+    const readings = await findTankReadings(db, tx.id)
+    expect(readings?.before_center).toBe(0)
+    expect(readings?.after_center).toBe(4000)
+    expect(readings?.before_total).toBeNull()
+  })
+
+  it('can be cleared back to null (all fields null)', async () => {
+    const tx = await createTransaction(db, { ticket_number: 'CLEAR-1', tail_number: 'N1CLR' })
+    await updateTankReadings(db, tx.id, {
+      before_left: 100,
+      before_right: 100,
+      before_center: null,
+      before_total: null,
+      after_left: 200,
+      after_right: 200,
+      after_center: null,
+      after_total: null,
+    })
+    expect(await findTankReadings(db, tx.id)).not.toBeNull()
+
+    await updateTankReadings(db, tx.id, {
+      before_left: null,
+      before_right: null,
+      before_center: null,
+      before_total: null,
+      after_left: null,
+      after_right: null,
+      after_center: null,
+      after_total: null,
+    })
+    expect(await findTankReadings(db, tx.id)).toBeNull()
   })
 })
 
@@ -277,14 +332,33 @@ describe('billing a fuel_transaction', () => {
     expect(queue).toEqual([])
   })
 
-  it('refuses to bill the same fuel_transaction twice (double-billing guard)', async () => {
+  it('refuses to bill the same fuel_transaction twice, with a friendly message, and logs it', async () => {
     const tx = await createTransaction(db, {
       ticket_number: 'ONCE',
       tail_number: 'N116FE',
       progress: 'completed',
     })
     await billTransaction(tx.id)
-    await expect(billTransaction(tx.id)).rejects.toMatchObject({ code: '23505' })
+
+    await expect(billTransaction(tx.id)).rejects.toMatchObject({
+      name: 'ConstraintViolationError',
+      sqlCode: '23505',
+      constraintName: 'uq_invoice_line_items_fuel_transaction',
+      message: 'This fueling has already been added to another invoice.',
+    })
+
+    const { data: logRows } = await db
+      .from('app_error_log')
+      .select('*')
+      .eq('category', 'db_constraint')
+    expect(logRows).toHaveLength(1)
+    expect(logRows?.[0]).toMatchObject({
+      error_code: 'uq_invoice_line_items_fuel_transaction',
+      message: 'This fueling has already been added to another invoice.',
+      source: 'invoices.repo.createInvoice',
+    })
+    expect(logRows?.[0].context).toMatchObject({ fuel_transaction_id: tx.id })
+    expect(logRows?.[0].detail).toContain('23505')
   })
 
   it('voiding the invoice releases the transaction for rebilling', async () => {
@@ -302,7 +376,7 @@ describe('billing a fuel_transaction', () => {
     expect(rebilled.line_items[0].fuel_transaction_id).toBe(tx.id)
   })
 
-  it('blocks deleting a billed transaction (void the invoice first)', async () => {
+  it('blocks deleting a billed transaction with a friendly message, and logs it', async () => {
     const tx = await createTransaction(db, {
       ticket_number: 'RESTRICT',
       tail_number: 'N116FE',
@@ -310,7 +384,20 @@ describe('billing a fuel_transaction', () => {
     })
     const invoice = await billTransaction(tx.id)
 
-    await expect(deleteTransaction(db, tx.id)).rejects.toMatchObject({ code: '23503' })
+    await expect(deleteTransaction(db, tx.id)).rejects.toMatchObject({
+      name: 'ConstraintViolationError',
+      sqlCode: '23503',
+      constraintName: 'invoice_line_items_fuel_transaction_id_fkey',
+      message:
+        'This fueling has already been billed to an invoice — void the invoice before deleting it.',
+    })
+
+    const { data: logRows } = await db
+      .from('app_error_log')
+      .select('*')
+      .eq('source', 'transactions.repo.deleteTransaction')
+    expect(logRows).toHaveLength(1)
+    expect(logRows?.[0].context).toMatchObject({ fuel_transaction_id: tx.id })
 
     await voidInvoice(db, invoice)
     await deleteTransaction(db, tx.id) // now allowed

--- a/frontend/repositories/invoices.repo.ts
+++ b/frontend/repositories/invoices.repo.ts
@@ -2,6 +2,7 @@ import {
   type PositionReading,
   lineAmount
 } from '@/components/invoicing/ticket-math'
+import { handleWriteError } from '@/lib/db-errors'
 import {
   type TruckMeterReadingRow,
   deleteFuelingEvent,
@@ -380,7 +381,23 @@ export async function createInvoice(
         })
         .select('id')
         .single()
-      if (fuelItemError) throw fuelItemError
+      if (fuelItemError) {
+        // Most likely uq_invoice_line_items_fuel_transaction (double-billing
+        // the same fuel_transaction) or the older
+        // uq_invoice_line_items_meter_reading — translated into a clear
+        // message and logged to app_error_log; see lib/db-errors.ts.
+        // handleWriteError always throws; the throw below is unreachable in
+        // practice but keeps TS's control-flow narrowing of `fuelItem` happy.
+        await handleWriteError(db, fuelItemError, {
+          source: 'invoices.repo.createInvoice',
+          context: {
+            invoice_id: invoice.id,
+            fuel_transaction_id: fuelTransactionId,
+            truck_meter_reading_id: meterReadingId
+          }
+        })
+        throw fuelItemError
+      }
       fuelLineItemId = fuelItem.id
     }
 

--- a/frontend/repositories/invoices.repo.ts
+++ b/frontend/repositories/invoices.repo.ts
@@ -15,6 +15,27 @@ export type InvoiceInsert = TablesInsert<'invoices'>
 export type InvoiceStatus = InvoiceRow['status']
 export type PaymentMethod = NonNullable<InvoiceRow['payment_method']>
 export type SettledVia = NonNullable<InvoiceRow['settled_via']>
+export type NumberSource = InvoiceRow['number_source']
+
+/**
+ * Classifies an invoice number by its shape: a bare 5-digit serial is a
+ * pre-printed paper-book number (airline books); everything else — dash
+ * format like '26-3330' first among them — is a live number issued by the
+ * accounting software. Only a default; callers can override explicitly.
+ */
+export function inferNumberSource(invoiceNumber: string): NumberSource {
+  return /^\d{5}$/.test(invoiceNumber.trim()) ? 'paper_book' : 'live'
+}
+
+/** Paper-book invoices whose top copy accounting hasn't collected yet. */
+export function isPendingAccountingPickup(
+  invoice: Pick<InvoiceRow, 'number_source' | 'accounting_picked_up_at'>
+): boolean {
+  return (
+    invoice.number_source === 'paper_book' &&
+    invoice.accounting_picked_up_at == null
+  )
+}
 
 export type LineItemRow = Tables<'invoice_line_items'>
 export type FuelReadingRow = Tables<'invoice_fuel_readings'>
@@ -33,6 +54,12 @@ export type MeterReadingWithSheet = TruckMeterReadingRow & {
 export type LineItemWithDetails = LineItemRow & {
   fuel_readings: FuelReadingRow[]
   meter_reading: MeterReadingWithSheet | null
+  fuel_transaction: {
+    id: number
+    ticket_number: string
+    tail_number: string | null
+    gallons_delivered: string | null
+  } | null
 }
 
 export type InvoiceWithItems = InvoiceRow & {
@@ -49,6 +76,9 @@ const INVOICE_SELECT = `
     meter_reading:truck_meter_reading_id (
       *,
       truck_sheet:truck_sheets ( id, truck_number, fuel_truck_id, sheet_date )
+    ),
+    fuel_transaction:fuel_transaction_id (
+      id, ticket_number, tail_number, gallons_delivered
     )
   )
 `
@@ -120,6 +150,14 @@ export async function suggestNextInvoiceNumber(
 }
 
 export interface FuelLineInput {
+  /**
+   * The dispatch record this line bills. A fuel_transaction becomes exactly
+   * ONE invoice line item — the partial unique index on
+   * invoice_line_items.fuel_transaction_id makes double-billing a database
+   * error, not a UI convention. When omitted but truckMeterReadingId is
+   * set, the reading's already-reconciled transaction (if any) is inherited.
+   */
+  fuelTransactionId?: number | null
   /** Bill an existing truck-sheet fueling event… */
   truckMeterReadingId?: number
   /** …or record a new one from digital ticket entry. */
@@ -166,6 +204,13 @@ export interface NewInvoiceInput {
     checkNumber: string | null
     salesmanInitials: string | null
     notes: string | null
+    /**
+     * 'live' = dash-format number ('26-3330') issued immediately by the
+     * accounting software; 'paper_book' = pre-printed 5-digit book serial
+     * ('21483', airlines), whose carbon copy accounting collects around
+     * midday. Omitted → inferred from the number's shape.
+     */
+    numberSource?: NumberSource
   }
   fuelLine: FuelLineInput | null
   serviceLines: ServiceLineInput[]
@@ -225,12 +270,25 @@ export async function createInvoice(
   //    real-world fuel delivery.
   let meterReadingId: number | null = null
   let createdFuelingId: number | null = null
+  let fuelTransactionId: number | null = fuelLine?.fuelTransactionId ?? null
   if (fuelLine) {
     if (fuelLine.replaceFuelingReadingId != null) {
       await deleteFuelingEvent(db, fuelLine.replaceFuelingReadingId)
     }
     if (fuelLine.truckMeterReadingId != null) {
       meterReadingId = fuelLine.truckMeterReadingId
+      // Billing a scanned sheet row that has already been reconciled with a
+      // dispatch record: the invoice line bills that transaction unless the
+      // caller explicitly chose one.
+      if (fuelTransactionId == null) {
+        const { data: linked, error: linkedError } = await db
+          .from('truck_meter_readings')
+          .select('fuel_transaction_id')
+          .eq('id', meterReadingId)
+          .single()
+        if (linkedError) throw linkedError
+        fuelTransactionId = linked.fuel_transaction_id
+      }
     } else if (fuelLine.newFueling) {
       const reading = await recordFuelingEvent(db, {
         fuelTruckId: fuelLine.newFueling.fuelTruckId,
@@ -281,7 +339,9 @@ export async function createInvoice(
       paid_at: paidAt,
       salesman_initials: header.salesmanInitials,
       total: invoiceTotal(input),
-      notes: header.notes
+      notes: header.notes,
+      number_source:
+        header.numberSource ?? inferNumberSource(header.invoiceNumber)
     })
     .select('id')
     .single()
@@ -308,6 +368,7 @@ export async function createInvoice(
           line_number: lineNumber++,
           item_type: 'fuel',
           truck_meter_reading_id: meterReadingId,
+          fuel_transaction_id: fuelTransactionId,
           description: FUEL_TYPE_LABELS[fuelLine.fuelType],
           quantity: fuelLine.quantityGallons,
           unit_price: fuelLine.pricePerGallon,
@@ -446,28 +507,57 @@ export async function settleInvoice(
 }
 
 /**
+ * Marks a paper-book invoice's carbon copy as collected by accounting (the
+ * midday box pickup). Until this runs, the invoice reads as "pending
+ * accounting pickup" — see isPendingAccountingPickup().
+ */
+export async function markAccountingPickedUp(
+  db: SupabaseClient<Database>,
+  id: number,
+  pickedUpAt: string = new Date().toISOString()
+): Promise<InvoiceWithItems> {
+  const { error } = await db
+    .from('invoices')
+    .update({
+      accounting_picked_up_at: pickedUpAt,
+      updated_at: new Date().toISOString()
+    })
+    .eq('id', id)
+    .eq('number_source', 'paper_book')
+  if (error) throw error
+
+  const updated = await getInvoiceById(db, id)
+  if (!updated) throw new Error('Invoice not found after pickup update')
+  return updated
+}
+
+/**
  * Voids an invoice and releases its fueling event (clears the line-item
- * link and the invoice number stamped on the truck-sheet row) so the
- * event can be rebilled on a corrected ticket.
+ * links — both the truck-sheet row and the dispatch record — and the
+ * invoice number stamped on the truck-sheet row) so the event can be
+ * rebilled on a corrected ticket. Releasing fuel_transaction_id is what
+ * frees the uniqueness slot in uq_invoice_line_items_fuel_transaction.
  */
 export async function voidInvoice(
   db: SupabaseClient<Database>,
   invoice: InvoiceWithItems
 ): Promise<void> {
   const fuelLines = invoice.line_items.filter(
-    (li) => li.truck_meter_reading_id != null
+    (li) => li.truck_meter_reading_id != null || li.fuel_transaction_id != null
   )
 
   for (const line of fuelLines) {
-    const { error: unstampError } = await db
-      .from('truck_meter_readings')
-      .update({ invoice_number: null })
-      .eq('id', line.truck_meter_reading_id as number)
-    if (unstampError) throw unstampError
+    if (line.truck_meter_reading_id != null) {
+      const { error: unstampError } = await db
+        .from('truck_meter_readings')
+        .update({ invoice_number: null })
+        .eq('id', line.truck_meter_reading_id)
+      if (unstampError) throw unstampError
+    }
 
     const { error: unlinkError } = await db
       .from('invoice_line_items')
-      .update({ truck_meter_reading_id: null })
+      .update({ truck_meter_reading_id: null, fuel_transaction_id: null })
       .eq('id', line.id)
     if (unlinkError) throw unlinkError
   }

--- a/frontend/repositories/scanned-documents.repo.ts
+++ b/frontend/repositories/scanned-documents.repo.ts
@@ -1,0 +1,193 @@
+import type { Database, Tables } from '@/types/database'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * Original scans of the two paper document types (see
+ * docs/architecture/fuel-invoicing-workflow.md and
+ * scripts/fuel-invoicing-workflow-schema.sql):
+ *
+ *   - truck_sheet   — "Truck Sheet Jet A" daily meter log, one photo per
+ *                     page; a busy truck's sheet spans several photos
+ *                     (page_number keeps their order).
+ *   - invoice_slip  — carbon-copy page from a pre-printed invoice book
+ *                     (5-digit red serial), one photo per slip.
+ *
+ * Files live in the private 'scans' Storage bucket; this table is the
+ * metadata + linkage record. Per the workflow's resilience posture a scan
+ * can be uploaded before anyone knows which truck_sheet/invoice it belongs
+ * to — both FKs are nullable and linked later.
+ */
+
+export const SCANS_BUCKET = 'scans'
+
+export type ScannedDocumentRow = Tables<'scanned_documents'>
+export type ScannedDocType = ScannedDocumentRow['doc_type']
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[^A-Za-z0-9._-]+/g, '_').slice(-80)
+}
+
+/** {doc_type}/{yyyy}/{mm}/{uuid}-{filename} — unique, sortable, greppable. */
+export function buildScanPath(docType: ScannedDocType, filename: string): string {
+  const now = new Date()
+  const yyyy = now.getUTCFullYear()
+  const mm = String(now.getUTCMonth() + 1).padStart(2, '0')
+  return `${docType}/${yyyy}/${mm}/${crypto.randomUUID()}-${sanitizeFilename(filename)}`
+}
+
+export interface UploadScanInput {
+  docType: ScannedDocType
+  file: File | Blob
+  filename: string
+  pageNumber?: number | null
+  truckSheetId?: number | null
+  invoiceId?: number | null
+  notes?: string | null
+}
+
+/**
+ * Persists an original scan: uploads the bytes to the private bucket, then
+ * records the metadata row. If the metadata insert fails the uploaded
+ * object is removed best-effort so the bucket doesn't accumulate orphans.
+ */
+export async function uploadScannedDocument(
+  db: SupabaseClient<Database>,
+  input: UploadScanInput
+): Promise<ScannedDocumentRow> {
+  const path = buildScanPath(input.docType, input.filename)
+  const contentType =
+    input.file instanceof File && input.file.type
+      ? input.file.type
+      : 'application/octet-stream'
+
+  const { error: uploadError } = await db.storage
+    .from(SCANS_BUCKET)
+    .upload(path, input.file, { contentType, upsert: false })
+  if (uploadError) throw uploadError
+
+  const { data, error } = await db
+    .from('scanned_documents')
+    .insert({
+      doc_type: input.docType,
+      storage_bucket: SCANS_BUCKET,
+      storage_path: path,
+      original_filename: input.filename,
+      content_type: contentType,
+      byte_size: input.file.size,
+      page_number: input.pageNumber ?? null,
+      truck_sheet_id: input.truckSheetId ?? null,
+      invoice_id: input.invoiceId ?? null,
+      notes: input.notes ?? null
+    })
+    .select()
+    .single()
+  if (error) {
+    await db.storage.from(SCANS_BUCKET).remove([path])
+    throw error
+  }
+  return data
+}
+
+/** Signed URL for viewing a scan (the bucket is private by design). */
+export async function getScanSignedUrl(
+  db: SupabaseClient<Database>,
+  doc: Pick<ScannedDocumentRow, 'storage_bucket' | 'storage_path'>,
+  expiresInSeconds = 3600
+): Promise<string> {
+  const { data, error } = await db.storage
+    .from(doc.storage_bucket)
+    .createSignedUrl(doc.storage_path, expiresInSeconds)
+  if (error) throw error
+  return data.signedUrl
+}
+
+export async function findScansForTruckSheet(
+  db: SupabaseClient<Database>,
+  truckSheetId: number
+): Promise<ScannedDocumentRow[]> {
+  const { data, error } = await db
+    .from('scanned_documents')
+    .select('*')
+    .eq('truck_sheet_id', truckSheetId)
+    .order('page_number', { ascending: true, nullsFirst: false })
+    .order('created_at')
+  if (error) throw error
+  return data
+}
+
+export async function findScansForInvoice(
+  db: SupabaseClient<Database>,
+  invoiceId: number
+): Promise<ScannedDocumentRow[]> {
+  const { data, error } = await db
+    .from('scanned_documents')
+    .select('*')
+    .eq('invoice_id', invoiceId)
+    .order('created_at')
+  if (error) throw error
+  return data
+}
+
+/** Scans uploaded but not yet matched to a truck sheet / invoice. */
+export async function findUnlinkedScans(
+  db: SupabaseClient<Database>,
+  docType?: ScannedDocType
+): Promise<ScannedDocumentRow[]> {
+  let q = db
+    .from('scanned_documents')
+    .select('*')
+    .is('truck_sheet_id', null)
+    .is('invoice_id', null)
+    .order('created_at', { ascending: false })
+  if (docType) q = q.eq('doc_type', docType)
+  const { data, error } = await q
+  if (error) throw error
+  return data
+}
+
+export async function linkScanToTruckSheet(
+  db: SupabaseClient<Database>,
+  scanId: number,
+  truckSheetId: number,
+  pageNumber?: number | null
+): Promise<ScannedDocumentRow> {
+  const { data, error } = await db
+    .from('scanned_documents')
+    .update({
+      truck_sheet_id: truckSheetId,
+      ...(pageNumber !== undefined ? { page_number: pageNumber } : {})
+    })
+    .eq('id', scanId)
+    .select()
+    .single()
+  if (error) throw error
+  return data
+}
+
+export async function linkScanToInvoice(
+  db: SupabaseClient<Database>,
+  scanId: number,
+  invoiceId: number
+): Promise<ScannedDocumentRow> {
+  const { data, error } = await db
+    .from('scanned_documents')
+    .update({ invoice_id: invoiceId })
+    .eq('id', scanId)
+    .select()
+    .single()
+  if (error) throw error
+  return data
+}
+
+/** Removes the metadata row AND the stored object. */
+export async function deleteScannedDocument(
+  db: SupabaseClient<Database>,
+  doc: Pick<ScannedDocumentRow, 'id' | 'storage_bucket' | 'storage_path'>
+): Promise<void> {
+  const { error } = await db.from('scanned_documents').delete().eq('id', doc.id)
+  if (error) throw error
+  const { error: storageError } = await db.storage
+    .from(doc.storage_bucket)
+    .remove([doc.storage_path])
+  if (storageError) throw storageError
+}

--- a/frontend/repositories/transactions.repo.ts
+++ b/frontend/repositories/transactions.repo.ts
@@ -1,4 +1,5 @@
 import { ConcurrencyConflictError } from '@/lib/concurrency'
+import { handleWriteError } from '@/lib/db-errors'
 import type {
   Database,
   Tables,
@@ -128,7 +129,15 @@ export async function deleteTransaction(
   id: number
 ): Promise<void> {
   const { error } = await db.from('fuel_transaction').delete().eq('id', id)
-  if (error) throw error
+  if (error) {
+    // Most likely invoice_line_items_fuel_transaction_id_fkey (ON DELETE
+    // RESTRICT — this fueling is already billed on an invoice). Translated
+    // into a clear message and logged; see lib/db-errors.ts.
+    await handleWriteError(db, error, {
+      source: 'transactions.repo.deleteTransaction',
+      context: { fuel_transaction_id: id }
+    })
+  }
 }
 
 // ============================================================
@@ -270,50 +279,97 @@ export async function unlinkReading(
   if (error) throw error
 }
 
-export type TankReadingRow = Tables<'fuel_transaction_tank_readings'>
-export type TankReadingInput = {
-  tank_position: string // e.g. 'L' / 'C' / 'R' (737), 'L' / 'R' / 'T' (E175) — free-form by design
-  reading_before: number | null
-  reading_after: number | null
-  reading_unit?: 'lbs' | 'gal' | 'kg'
+/**
+ * Optional per-tank before/after readings for airline fuelings, as fixed,
+ * explicitly-named columns on fuel_transaction (not a normalized per-row
+ * table — see docs/architecture/fuel-invoicing-workflow.md for why: fixed
+ * columns let plain SQL (AVG/GROUP BY) aggregate directly for analytics
+ * like "average fuel taken by airline X", where a pivoted EAV-style table
+ * would need a pivot on every query).
+ *
+ * `center` is a real third tank on 737s; E175 has no center tank (its L/R/T
+ * layout's "T" is the Total reading, not a tank) so `center` stays null for
+ * E175 fuelings. `total` is recorded for both. All eight fields — and the
+ * whole group — are optional: GA fuelings simply never set any of these.
+ */
+export interface TankReadings {
+  before_left: number | null
+  before_right: number | null
+  before_center: number | null
+  before_total: number | null
+  after_left: number | null
+  after_right: number | null
+  after_center: number | null
+  after_total: number | null
+  unit?: 'lbs' | 'gal' | 'kg'
 }
 
-export async function findTankReadings(
-  db: SupabaseClient<Database>,
-  transactionId: number
-): Promise<TankReadingRow[]> {
-  const { data, error } = await db
-    .from('fuel_transaction_tank_readings')
-    .select('*')
-    .eq('fuel_transaction_id', transactionId)
-    .order('tank_position')
-  if (error) throw error
-  return data
+function numOrNull(v: string | null): number | null {
+  return v == null ? null : Number(v)
 }
 
 /**
- * Replaces the optional per-tank before/after readings for an airline
- * fueling (GA transactions simply never call this). Delete-then-insert
- * keeps the (transaction, position) set exactly what the caller supplied.
+ * Reads back the eight tank-reading columns as the TankReadings shape.
+ * Postgres numeric columns come back from PostgREST as strings (same as
+ * fuel_transaction.quantity_gallons etc.) — converted to numbers here so
+ * callers get plain numbers, matching the shape updateTankReadings accepts.
  */
-export async function replaceTankReadings(
+export async function findTankReadings(
+  db: SupabaseClient<Database>,
+  transactionId: number
+): Promise<TankReadings | null> {
+  const { data, error } = await db
+    .from('fuel_transaction')
+    .select(
+      'tank_reading_before_left, tank_reading_before_right, tank_reading_before_center, tank_reading_before_total, tank_reading_after_left, tank_reading_after_right, tank_reading_after_center, tank_reading_after_total, tank_reading_unit'
+    )
+    .eq('id', transactionId)
+    .single()
+  if (error) throw error
+  if (
+    data.tank_reading_before_left == null &&
+    data.tank_reading_before_right == null &&
+    data.tank_reading_before_center == null &&
+    data.tank_reading_before_total == null &&
+    data.tank_reading_after_left == null &&
+    data.tank_reading_after_right == null &&
+    data.tank_reading_after_center == null &&
+    data.tank_reading_after_total == null
+  ) {
+    return null
+  }
+  return {
+    before_left: numOrNull(data.tank_reading_before_left),
+    before_right: numOrNull(data.tank_reading_before_right),
+    before_center: numOrNull(data.tank_reading_before_center),
+    before_total: numOrNull(data.tank_reading_before_total),
+    after_left: numOrNull(data.tank_reading_after_left),
+    after_right: numOrNull(data.tank_reading_after_right),
+    after_center: numOrNull(data.tank_reading_after_center),
+    after_total: numOrNull(data.tank_reading_after_total),
+    unit: data.tank_reading_unit
+  }
+}
+
+/**
+ * Sets (or clears, by passing all-null fields) the per-tank readings for an
+ * airline fueling. A plain field-for-field update — this is 1:1 data on
+ * fuel_transaction, not a related table, so there's nothing to replace/merge.
+ */
+export async function updateTankReadings(
   db: SupabaseClient<Database>,
   transactionId: number,
-  readings: TankReadingInput[]
-): Promise<TankReadingRow[]> {
-  const { error: clearError } = await db
-    .from('fuel_transaction_tank_readings')
-    .delete()
-    .eq('fuel_transaction_id', transactionId)
-  if (clearError) throw clearError
-
-  if (readings.length === 0) return []
-  const { data, error } = await db
-    .from('fuel_transaction_tank_readings')
-    .insert(
-      readings.map((r) => ({ ...r, fuel_transaction_id: transactionId }))
-    )
-    .select()
-  if (error) throw error
-  return data
+  readings: TankReadings
+): Promise<TransactionRow> {
+  return updateTransaction(db, transactionId, {
+    tank_reading_before_left: readings.before_left,
+    tank_reading_before_right: readings.before_right,
+    tank_reading_before_center: readings.before_center,
+    tank_reading_before_total: readings.before_total,
+    tank_reading_after_left: readings.after_left,
+    tank_reading_after_right: readings.after_right,
+    tank_reading_after_center: readings.after_center,
+    tank_reading_after_total: readings.after_total,
+    ...(readings.unit ? { tank_reading_unit: readings.unit } : {})
+  })
 }

--- a/frontend/repositories/transactions.repo.ts
+++ b/frontend/repositories/transactions.repo.ts
@@ -73,6 +73,15 @@ export async function findTransactionById(
   return data as TransactionWithRelations | null
 }
 
+/**
+ * Creates a dispatch record. This is deliberately the single, clean entry
+ * point for "a fueling happened / was called in" — dispatch UI, digital
+ * ticket entry, and (future phase, see
+ * docs/architecture/fuel-invoicing-workflow.md) an AI chatbot tool-call all
+ * funnel through here. Keep it callable with just the radioed-in minimum:
+ * tail number, customer, gallons, free-form fuel_request. Meter numbers
+ * arrive later via truck-sheet scan reconciliation (linkReadingToTransaction).
+ */
 export async function createTransaction(
   db: SupabaseClient<Database>,
   tx: TransactionInsert
@@ -120,4 +129,191 @@ export async function deleteTransaction(
 ): Promise<void> {
   const { error } = await db.from('fuel_transaction').delete().eq('id', id)
   if (error) throw error
+}
+
+// ============================================================
+// Dispatch → invoicing workflow
+// (see docs/architecture/fuel-invoicing-workflow.md)
+// ============================================================
+
+/**
+ * Best-effort gallons from a free-form fuel request. 'T/O', 'Fill', lbs
+ * requests ('2700 lbs') and anything else non-obvious return null — per the
+ * domain spec, gallons_requested is optional and never guessed at.
+ * Examples: '300' → 300, '110/s Jet A+' → 110, '1,249 gal' → 1249.
+ */
+export function parseGallonsRequested(
+  fuelRequest: string | null | undefined
+): number | null {
+  if (!fuelRequest) return null
+  const text = fuelRequest.trim()
+  const match = text.match(/^([\d,]+(?:\.\d+)?)/)
+  if (!match) return null
+  if (/^\s*(?:lbs?|#|kgs?)\b/i.test(text.slice(match[0].length))) return null
+  const n = Number(match[1].replace(/,/g, ''))
+  return Number.isFinite(n) && n > 0 ? n : null
+}
+
+export type UninvoicedTransaction = TransactionWithRelations & {
+  invoice_line_items: Array<{ id: number }>
+}
+
+/**
+ * Completed fuelings with no invoice line yet — the front desk's
+ * "not yet invoiced" queue (and the view a future chatbot-created
+ * transaction lands in). PostgREST can't express NOT EXISTS, so the
+ * referencing line items are embedded and empties filtered client-side,
+ * mirroring findUnbilledFuelings in fueling-events.repo.ts.
+ */
+export async function findUninvoicedTransactions(
+  db: SupabaseClient<Database>,
+  days = 14
+): Promise<UninvoicedTransaction[]> {
+  const since = new Date()
+  since.setDate(since.getDate() - days)
+
+  const { data, error } = await db
+    .from('fuel_transaction')
+    .select(`${TX_SELECT}, invoice_line_items ( id )`)
+    .eq('progress', 'completed')
+    .gte('created_at', since.toISOString())
+    .order('created_at', { ascending: false })
+  if (error) throw error
+
+  const rows = data as unknown as UninvoicedTransaction[]
+  return rows.filter((tx) => tx.invoice_line_items.length === 0)
+}
+
+export type MatchCandidate = TransactionRow & {
+  truck_meter_readings: Array<{ id: number }>
+}
+
+/**
+ * Dispatch records that plausibly correspond to a scanned truck-sheet row,
+ * for the async reconciliation step. Matching is deliberately loose (the
+ * resilience requirement: scanned data is incomplete and inconsistent):
+ * same tail number, created within the sheet date ± 1 day (night shift
+ * crosses midnight). Already-linked readings are embedded so callers can
+ * rank unlinked transactions first — a candidate with existing links is
+ * still valid (one fueling can span front + rear register rows).
+ */
+export async function findMatchCandidates(
+  db: SupabaseClient<Database>,
+  input: { tailNumber: string | null; sheetDate: string }
+): Promise<MatchCandidate[]> {
+  if (!input.tailNumber?.trim()) return []
+
+  const dayStart = new Date(`${input.sheetDate}T00:00:00Z`)
+  const from = new Date(dayStart.getTime() - 24 * 60 * 60 * 1000)
+  const to = new Date(dayStart.getTime() + 2 * 24 * 60 * 60 * 1000)
+
+  const { data, error } = await db
+    .from('fuel_transaction')
+    .select('*, truck_meter_readings ( id )')
+    .ilike('tail_number', input.tailNumber.trim())
+    .gte('created_at', from.toISOString())
+    .lt('created_at', to.toISOString())
+    .order('created_at', { ascending: false })
+  if (error) throw error
+  return data as unknown as MatchCandidate[]
+}
+
+/**
+ * Links a scanned truck-sheet row to its dispatch record (the async
+ * reconciliation write). Also backfills gallons_delivered from the sheet's
+ * gallons-pumped figure when dispatch never got one — the scan is the
+ * better source for numbers that were skipped on the radio.
+ */
+export async function linkReadingToTransaction(
+  db: SupabaseClient<Database>,
+  readingId: number,
+  transactionId: number
+): Promise<void> {
+  const { error } = await db
+    .from('truck_meter_readings')
+    .update({ fuel_transaction_id: transactionId })
+    .eq('id', readingId)
+  if (error) throw error
+
+  const { data: tx, error: txError } = await db
+    .from('fuel_transaction')
+    .select('id, gallons_delivered')
+    .eq('id', transactionId)
+    .single()
+  if (txError) throw txError
+
+  if (tx.gallons_delivered == null) {
+    const { data: reading, error: readingError } = await db
+      .from('truck_meter_readings')
+      .select('gallons_pumped')
+      .eq('id', readingId)
+      .single()
+    if (readingError) throw readingError
+    if (reading.gallons_pumped != null) {
+      const { error: backfillError } = await db
+        .from('fuel_transaction')
+        .update({ gallons_delivered: reading.gallons_pumped })
+        .eq('id', transactionId)
+      if (backfillError) throw backfillError
+    }
+  }
+}
+
+export async function unlinkReading(
+  db: SupabaseClient<Database>,
+  readingId: number
+): Promise<void> {
+  const { error } = await db
+    .from('truck_meter_readings')
+    .update({ fuel_transaction_id: null })
+    .eq('id', readingId)
+  if (error) throw error
+}
+
+export type TankReadingRow = Tables<'fuel_transaction_tank_readings'>
+export type TankReadingInput = {
+  tank_position: string // e.g. 'L' / 'C' / 'R' (737), 'L' / 'R' / 'T' (E175) — free-form by design
+  reading_before: number | null
+  reading_after: number | null
+  reading_unit?: 'lbs' | 'gal' | 'kg'
+}
+
+export async function findTankReadings(
+  db: SupabaseClient<Database>,
+  transactionId: number
+): Promise<TankReadingRow[]> {
+  const { data, error } = await db
+    .from('fuel_transaction_tank_readings')
+    .select('*')
+    .eq('fuel_transaction_id', transactionId)
+    .order('tank_position')
+  if (error) throw error
+  return data
+}
+
+/**
+ * Replaces the optional per-tank before/after readings for an airline
+ * fueling (GA transactions simply never call this). Delete-then-insert
+ * keeps the (transaction, position) set exactly what the caller supplied.
+ */
+export async function replaceTankReadings(
+  db: SupabaseClient<Database>,
+  transactionId: number,
+  readings: TankReadingInput[]
+): Promise<TankReadingRow[]> {
+  const { error: clearError } = await db
+    .from('fuel_transaction_tank_readings')
+    .delete()
+    .eq('fuel_transaction_id', transactionId)
+  if (clearError) throw clearError
+
+  if (readings.length === 0) return []
+  const { data, error } = await db
+    .from('fuel_transaction_tank_readings')
+    .insert(
+      readings.map((r) => ({ ...r, fuel_transaction_id: transactionId }))
+    )
+    .select()
+  if (error) throw error
+  return data
 }

--- a/frontend/scripts/error-logging-schema.sql
+++ b/frontend/scripts/error-logging-schema.sql
@@ -1,0 +1,75 @@
+-- App Error Log
+-- Run this in the Supabase SQL Editor (supabase.com/dashboard → SQL Editor).
+-- This is Supabase-native (not Django-managed) and general-purpose — not
+-- specific to invoicing or any other single module.
+--
+-- Why this exists: deployment is Docker on a VPS with no log aggregation
+-- set up. Container stdout is ephemeral and not queryable after the fact,
+-- so when a user reports "something went wrong", there is currently no way
+-- to reconstruct what actually happened. This table is that durable
+-- record.
+--
+-- Writer: frontend/lib/error-logging.ts's logAppError() is the only
+-- intended writer. It's called from frontend/lib/db-errors.ts's
+-- handleWriteError() (constraint-violation handling in invoices.repo.ts /
+-- transactions.repo.ts is its first real usage) and can be adopted by any
+-- other part of the app later — this table is deliberately not
+-- invoicing-specific.
+--
+-- Designed to be queryable ("what happened around timestamp X for user
+-- Y?") since a future support tool (human or, per Ted's long-term idea, a
+-- chatbot) may query this — see docs/architecture/fuel-invoicing-workflow.md's
+-- future-phase note. No such tool is built here; this table just doesn't
+-- preclude it.
+
+CREATE TABLE IF NOT EXISTS app_error_log (
+  id          BIGSERIAL PRIMARY KEY,
+  occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- Coarse, stable bucket for grouping/querying. See ErrorCategory in
+  -- lib/error-logging.ts for the exact set this app writes today; left as
+  -- plain TEXT (no CHECK) so a new category never needs a migration.
+  category    TEXT NOT NULL,
+
+  -- Short machine code: a Postgres constraint name, a SQLSTATE, or an
+  -- app-defined code for non-DB errors. Not shown to end users.
+  error_code  TEXT NOT NULL,
+
+  -- Human-readable summary — may match what the user saw, but this column
+  -- exists for the log entry, not as the UI's source of truth.
+  message     TEXT NOT NULL,
+
+  -- Full technical detail (raw error message/stack/Postgres details+hint).
+  -- NEVER surfaced to end users — for developers / a future support tool only.
+  detail      TEXT,
+
+  -- Relevant entity ids, e.g. {"invoice_id": 5, "fuel_transaction_id": 12}.
+  context     JSONB,
+
+  -- Acting user, when available from the session. No FK to auth.users on
+  -- purpose: this log must still accept entries if the user record is
+  -- later deleted, and service-role callers legitimately have no user.
+  user_id     UUID,
+
+  -- Where in the code this was raised, e.g. 'invoices.repo.createInvoice'.
+  source      TEXT,
+
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_error_log_occurred_at ON app_error_log(occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_app_error_log_user_id     ON app_error_log(user_id) WHERE user_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_app_error_log_category    ON app_error_log(category);
+CREATE INDEX IF NOT EXISTS idx_app_error_log_context_gin ON app_error_log USING GIN (context);
+
+ALTER TABLE app_error_log ENABLE ROW LEVEL SECURITY;
+
+-- House style (authenticated users manage all), matching every other
+-- Supabase-native table in this project. Tightening this later (e.g.
+-- insert-only for regular users, reads restricted to an admin/support
+-- role via the existing roles/module_permissions system) is a reasonable
+-- follow-up, not blocking now — there's no PII here beyond user_id.
+DROP POLICY IF EXISTS "Authenticated users can manage app error log" ON app_error_log;
+CREATE POLICY "Authenticated users can manage app error log"
+  ON app_error_log FOR ALL
+  USING (auth.role() = 'authenticated');

--- a/frontend/scripts/fuel-invoicing-workflow-schema.sql
+++ b/frontend/scripts/fuel-invoicing-workflow-schema.sql
@@ -36,6 +36,9 @@
 --     slips) are persisted in Supabase Storage via the scanned_documents
 --     table + the private 'scans' bucket (today only OCR JSON survives; the
 --     photos are discarded).
+--   * Optional per-tank before/after readings for airline fuelings are fixed,
+--     explicitly-named columns on fuel_transaction (not a normalized side
+--     table) so plain SQL can aggregate them directly for analytics.
 --
 -- Data-resilience posture (hard requirement): every linkage below is
 -- nullable and populated after the fact. A fuel_transaction with no sheet
@@ -101,27 +104,45 @@ COMMENT ON COLUMN truck_meter_readings.fuel_transaction_id IS 'Matched dispatch 
 -- ============================================================
 -- 3. Per-tank before/after readings (airline fuelings only).
 --    Recorded on the invoice slip and per-airline paperwork for airline
---    aircraft: 737 uses L/C/R tanks, E175 uses L/R/T. tank_position is
---    free-form TEXT on purpose — other types/layouts must not require a
---    migration. Units are usually lbs (gauge readings), occasionally gal.
---    Optional for every transaction; GA fuelings never have these.
---    (invoice_fuel_readings remains the transcription of what's printed in
---    the invoice DESCRIPTION block; this table is the transaction-side
---    record, attached to the fueling event itself.)
+--    aircraft: 737 uses L/C/R tanks (a real center tank); E175 uses L/R/T,
+--    but the "T" there is almost certainly the Total reading, not a third
+--    physical tank — E175 has no center tank. So: fixed left/right/center/
+--    total columns, all nullable; center stays null for aircraft without
+--    one, total is recorded for both. This is 1:1 supplemental data on the
+--    transaction (one set of readings per fueling, never one-to-many), and
+--    fixed columns are deliberate over a normalized per-position table:
+--    Ted wants to run analytics later (e.g. average fuel taken by a given
+--    airline/aircraft type), and plain SQL (AVG, GROUP BY) aggregates fixed
+--    columns directly — a normalized row-per-position table would need a
+--    pivot on every such query. Optional for every transaction; GA fuelings
+--    never set these. (invoice_fuel_readings remains the transcription of
+--    what's printed in the invoice DESCRIPTION block — a different, ticket-
+--    side record.)
 -- ============================================================
-CREATE TABLE IF NOT EXISTS fuel_transaction_tank_readings (
-  id                  BIGSERIAL PRIMARY KEY,
-  fuel_transaction_id BIGINT NOT NULL REFERENCES fuel_transaction(id) ON DELETE CASCADE,
-  tank_position       TEXT   NOT NULL CHECK (tank_position <> ''),  -- 'L','C','R','T', wing/aux names — free-form by design
-  reading_before      NUMERIC(12,1),
-  reading_after       NUMERIC(12,1),
-  reading_unit        TEXT   NOT NULL DEFAULT 'lbs' CHECK (reading_unit IN ('lbs', 'gal', 'kg')),
-  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  UNIQUE (fuel_transaction_id, tank_position)
-);
+ALTER TABLE fuel_transaction
+  ADD COLUMN IF NOT EXISTS tank_reading_before_left   NUMERIC(12,1),
+  ADD COLUMN IF NOT EXISTS tank_reading_before_right  NUMERIC(12,1),
+  ADD COLUMN IF NOT EXISTS tank_reading_before_center NUMERIC(12,1),
+  ADD COLUMN IF NOT EXISTS tank_reading_before_total  NUMERIC(12,1),
+  ADD COLUMN IF NOT EXISTS tank_reading_after_left    NUMERIC(12,1),
+  ADD COLUMN IF NOT EXISTS tank_reading_after_right   NUMERIC(12,1),
+  ADD COLUMN IF NOT EXISTS tank_reading_after_center  NUMERIC(12,1),
+  ADD COLUMN IF NOT EXISTS tank_reading_after_total   NUMERIC(12,1),
+  ADD COLUMN IF NOT EXISTS tank_reading_unit          TEXT NOT NULL DEFAULT 'lbs';
 
-CREATE INDEX IF NOT EXISTS idx_fuel_tx_tank_readings_tx
-  ON fuel_transaction_tank_readings(fuel_transaction_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'fuel_transaction_tank_reading_unit_check'
+  ) THEN
+    ALTER TABLE fuel_transaction
+      ADD CONSTRAINT fuel_transaction_tank_reading_unit_check
+      CHECK (tank_reading_unit IN ('lbs', 'gal', 'kg'));
+  END IF;
+END $$;
+
+COMMENT ON COLUMN fuel_transaction.tank_reading_before_center IS 'Real center-tank reading (737 L/C/R). NULL for aircraft types with no center tank (e.g. E175).';
+COMMENT ON COLUMN fuel_transaction.tank_reading_before_total  IS 'Totalizer reading (E175''s "T" in L/R/T). Recorded for both aircraft types.';
 
 -- ============================================================
 -- 4. invoice_line_items → fuel_transaction: the billing link.
@@ -257,14 +278,12 @@ COMMENT ON VIEW truck_sheet_running_totals IS 'Derived per-truck running fuel le
 
 -- ============================================================
 -- 8. RLS (house style: authenticated users manage all)
+--    fuel_transaction itself has no RLS (Django-era table, written directly
+--    via Supabase like the rest of the fuel-dispatch tables — see
+--    modified-at-triggers.sql) so the new tank_reading_* columns need no
+--    policy of their own.
 -- ============================================================
-ALTER TABLE fuel_transaction_tank_readings ENABLE ROW LEVEL SECURITY;
-ALTER TABLE scanned_documents              ENABLE ROW LEVEL SECURITY;
-
-DROP POLICY IF EXISTS "Authenticated users can manage tank readings" ON fuel_transaction_tank_readings;
-CREATE POLICY "Authenticated users can manage tank readings"
-  ON fuel_transaction_tank_readings FOR ALL
-  USING (auth.role() = 'authenticated');
+ALTER TABLE scanned_documents ENABLE ROW LEVEL SECURITY;
 
 DROP POLICY IF EXISTS "Authenticated users can manage scanned documents" ON scanned_documents;
 CREATE POLICY "Authenticated users can manage scanned documents"

--- a/frontend/scripts/fuel-invoicing-workflow-schema.sql
+++ b/frontend/scripts/fuel-invoicing-workflow-schema.sql
@@ -1,0 +1,287 @@
+-- Fuel Dispatch ↔ Truck Sheets ↔ Invoicing workflow linkage
+-- Run this in the Supabase SQL Editor (supabase.com/dashboard → SQL Editor).
+-- These changes are Supabase-native (not Django-managed).
+--
+-- DEPENDS ON (run first, in order):
+--   scripts/truck-sheets-schema.sql   (truck_sheets, truck_meter_readings)
+--   scripts/invoicing-schema.sql      (invoices, invoice_line_items, invoice_fuel_readings)
+--   scripts/fuel-order-schema.sql     (fuel_transaction dispatch columns)
+--
+-- Design doc: docs/architecture/fuel-invoicing-workflow.md (ER + sequence diagrams).
+--
+-- What this migration models (the real paper workflow on the ramp):
+--   * fuel_transaction is the LIVE dispatch record — created when a fueling is
+--     radioed in / dispatched, usually with NO meter numbers (too much data
+--     entry for a line tech on the radio). Just tail number, gallons, a
+--     free-form request.
+--   * truck_meter_readings rows arrive LATER, when the paper truck sheet is
+--     scanned (OCR) — they carry the real Meter Start/End numbers and link
+--     BACK to the dispatch record once matched. Nullable FK, matched
+--     asynchronously; sheets will not be scanned consistently, so nothing
+--     here is required at creation time.
+--   * A fuel_transaction becomes exactly ONE line item on an invoice (other
+--     line items — services, fluids, ramp fees — are added separately by the
+--     front desk). A partial unique index prevents billing the same fueling
+--     twice.
+--   * Two invoice-number regimes exist:
+--       - dash format, e.g. '26-3330' — issued LIVE by the accounting
+--         software while the line tech waits on the radio (GA traffic);
+--       - plain 5-digit book serial, e.g. '21483' — pre-printed in red in a
+--         carbon-copy paper invoice book (airlines). The slip is filled by
+--         hand at fueling time and accounting picks the copies up around
+--         midday, so there is a real, expected batch delay before the
+--         invoice is "known". invoices.number_source + accounting_picked_up_at
+--         model that pending-pickup state.
+--   * Original scans of BOTH paper document types (truck sheets AND invoice
+--     slips) are persisted in Supabase Storage via the scanned_documents
+--     table + the private 'scans' bucket (today only OCR JSON survives; the
+--     photos are discarded).
+--
+-- Data-resilience posture (hard requirement): every linkage below is
+-- nullable and populated after the fact. A fuel_transaction with no sheet
+-- row, a sheet row with no transaction, and an invoice with neither must all
+-- remain valid states — incomplete data is the norm during adoption, not an
+-- error.
+
+-- ============================================================
+-- 1. fuel_transaction: dispatch-time fields
+--    - fuel_order_text is renamed to fuel_request (Ted's field name; the
+--      dispatch UI already labels it "Fuel Request"). It holds the request
+--      exactly as written/radioed, e.g. 'T/O' or '110/s Jet A+'.
+--    - gallons_requested: best-effort number parsed from fuel_request;
+--      NULL whenever it can't be trivially derived (e.g. 'T/O', lbs
+--      requests). Never required.
+--    - gallons_delivered: the number actually radioed in to the front desk
+--      (a.k.a. "gallons pumped" on the sheet — this name preferred).
+--      Distinct from the legacy quantity_gallons (QT-era ordered quantity),
+--      which is left untouched.
+--    - customer_name: who to bill, as radioed/written ("Life Flight",
+--      'UA 5996'). Matches truck sheet "Customer" and invoice "Name".
+-- ============================================================
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'fuel_transaction' AND column_name = 'fuel_order_text'
+  ) THEN
+    ALTER TABLE fuel_transaction RENAME COLUMN fuel_order_text TO fuel_request;
+  END IF;
+END $$;
+
+ALTER TABLE fuel_transaction
+  ADD COLUMN IF NOT EXISTS fuel_request       TEXT,
+  ADD COLUMN IF NOT EXISTS gallons_requested  NUMERIC(10,2),
+  ADD COLUMN IF NOT EXISTS gallons_delivered  NUMERIC(10,2),
+  ADD COLUMN IF NOT EXISTS customer_name      TEXT;
+
+COMMENT ON COLUMN fuel_transaction.fuel_request      IS 'Free-form request as written on the truck sheet / radioed in, e.g. ''T/O'', ''110/s Jet A+''. Renamed from fuel_order_text.';
+COMMENT ON COLUMN fuel_transaction.gallons_requested IS 'Best-effort number parsed from fuel_request; NULL when not trivially derivable (T/O, lbs requests, etc.).';
+COMMENT ON COLUMN fuel_transaction.gallons_delivered IS 'Gallons actually pumped, as radioed in to front desk (name preferred over gallons_pumped).';
+COMMENT ON COLUMN fuel_transaction.customer_name     IS 'Customer as radioed/written — matches truck sheet Customer column and invoice Name field.';
+
+-- ============================================================
+-- 2. truck_meter_readings → fuel_transaction: the async
+--    scan-reconciliation link.
+--    The scanned sheet row points back to the dispatch record once matched
+--    (by tail number + date + gallons + invoice number). Intentionally NOT
+--    unique: a single big fueling can span multiple sheet rows (front +
+--    rear register on Jet A trucks). Double-billing is prevented at the
+--    invoice_line_items level (section 4), not here.
+-- ============================================================
+ALTER TABLE truck_meter_readings
+  ADD COLUMN IF NOT EXISTS fuel_transaction_id BIGINT
+    REFERENCES fuel_transaction(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_truck_meter_readings_fuel_transaction
+  ON truck_meter_readings(fuel_transaction_id)
+  WHERE fuel_transaction_id IS NOT NULL;
+
+COMMENT ON COLUMN truck_meter_readings.fuel_transaction_id IS 'Matched dispatch record. Populated asynchronously when the scanned sheet is reconciled — never required.';
+
+-- ============================================================
+-- 3. Per-tank before/after readings (airline fuelings only).
+--    Recorded on the invoice slip and per-airline paperwork for airline
+--    aircraft: 737 uses L/C/R tanks, E175 uses L/R/T. tank_position is
+--    free-form TEXT on purpose — other types/layouts must not require a
+--    migration. Units are usually lbs (gauge readings), occasionally gal.
+--    Optional for every transaction; GA fuelings never have these.
+--    (invoice_fuel_readings remains the transcription of what's printed in
+--    the invoice DESCRIPTION block; this table is the transaction-side
+--    record, attached to the fueling event itself.)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS fuel_transaction_tank_readings (
+  id                  BIGSERIAL PRIMARY KEY,
+  fuel_transaction_id BIGINT NOT NULL REFERENCES fuel_transaction(id) ON DELETE CASCADE,
+  tank_position       TEXT   NOT NULL CHECK (tank_position <> ''),  -- 'L','C','R','T', wing/aux names — free-form by design
+  reading_before      NUMERIC(12,1),
+  reading_after       NUMERIC(12,1),
+  reading_unit        TEXT   NOT NULL DEFAULT 'lbs' CHECK (reading_unit IN ('lbs', 'gal', 'kg')),
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (fuel_transaction_id, tank_position)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fuel_tx_tank_readings_tx
+  ON fuel_transaction_tank_readings(fuel_transaction_id);
+
+-- ============================================================
+-- 4. invoice_line_items → fuel_transaction: the billing link.
+--    A fuel_transaction is billed as at most ONE invoice line item (partial
+--    unique index). truck_meter_reading_id is kept for provenance/back-compat
+--    (which sheet row the meter data came from) but fuel_transaction_id is
+--    now the primary fueling↔invoice relationship.
+--    ON DELETE RESTRICT: a billed dispatch record cannot be deleted out from
+--    under its invoice — void the invoice first (voiding clears the link).
+-- ============================================================
+ALTER TABLE invoice_line_items
+  ADD COLUMN IF NOT EXISTS fuel_transaction_id BIGINT
+    REFERENCES fuel_transaction(id) ON DELETE RESTRICT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_invoice_line_items_fuel_transaction
+  ON invoice_line_items(fuel_transaction_id)
+  WHERE fuel_transaction_id IS NOT NULL;
+
+COMMENT ON COLUMN invoice_line_items.fuel_transaction_id IS 'The fueling billed by this line. Partial unique index prevents billing the same fuel_transaction twice.';
+
+-- ============================================================
+-- 5. invoices: the two invoice-number regimes.
+--    number_source:
+--      'live'       – dash format ('26-3330'), issued immediately by the
+--                     accounting software while the line tech waits.
+--      'paper_book' – 5-digit serial ('21483') pre-printed in the carbon
+--                     invoice book; filled by hand, top copy dropped in the
+--                     box, accounting collects around midday.
+--    Pending-pickup state is DERIVED, not a status enum value:
+--      pending  = number_source = 'paper_book' AND accounting_picked_up_at IS NULL
+--    No format CHECK on invoice_number on purpose — hand-written numbers are
+--    messy and the resilience posture forbids rejecting them.
+-- ============================================================
+ALTER TABLE invoices
+  ADD COLUMN IF NOT EXISTS number_source TEXT NOT NULL DEFAULT 'live'
+    CHECK (number_source IN ('live', 'paper_book')),
+  ADD COLUMN IF NOT EXISTS accounting_picked_up_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN invoices.number_source           IS '''live'' = dash-format number issued immediately by accounting software; ''paper_book'' = pre-printed 5-digit book serial (airlines).';
+COMMENT ON COLUMN invoices.accounting_picked_up_at IS 'When accounting collected the paper book copy (midday pickup). NULL + paper_book = pending pickup. Irrelevant for live invoices.';
+
+-- Backfill: classify existing invoices by number shape. 5-digit all-numeric =
+-- book serial; anything with a dash = live. Existing non-draft book invoices
+-- are assumed already collected (they were entered into this system at all).
+UPDATE invoices SET number_source = 'paper_book' WHERE invoice_number ~ '^\d{5}$';
+UPDATE invoices
+  SET accounting_picked_up_at = created_at
+  WHERE number_source = 'paper_book' AND status IN ('open', 'paid');
+
+CREATE INDEX IF NOT EXISTS idx_invoices_pending_pickup
+  ON invoices(invoice_date)
+  WHERE number_source = 'paper_book' AND accounting_picked_up_at IS NULL;
+
+-- ============================================================
+-- 6. scanned_documents + Storage: persist the original photos of BOTH paper
+--    document types. One private bucket ('scans'); path convention
+--    {doc_type}/{yyyy}/{mm}/{uuid}-{filename}. A truck sheet can have
+--    several pages (several rows here); an invoice slip is one image.
+--    Rows can exist before their document is matched to a truck_sheet /
+--    invoice — both FKs nullable, linked later like everything else.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS scanned_documents (
+  id                BIGSERIAL PRIMARY KEY,
+  doc_type          TEXT   NOT NULL CHECK (doc_type IN ('truck_sheet', 'invoice_slip')),
+  storage_bucket    TEXT   NOT NULL DEFAULT 'scans',
+  storage_path      TEXT   NOT NULL UNIQUE,
+  original_filename TEXT   NOT NULL,
+  content_type      TEXT   NOT NULL,
+  byte_size         BIGINT,
+  page_number       INTEGER,          -- 1-based page order for multi-page truck sheets
+  truck_sheet_id    BIGINT REFERENCES truck_sheets(id) ON DELETE SET NULL,
+  invoice_id        BIGINT REFERENCES invoices(id)     ON DELETE SET NULL,
+  uploaded_by       UUID,             -- auth.uid() of the uploader, when available
+  notes             TEXT,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_scanned_documents_truck_sheet
+  ON scanned_documents(truck_sheet_id) WHERE truck_sheet_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_scanned_documents_invoice
+  ON scanned_documents(invoice_id) WHERE invoice_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_scanned_documents_type_date
+  ON scanned_documents(doc_type, created_at DESC);
+
+-- Private bucket: scans are business paperwork; access via signed URLs only.
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('scans', 'scans', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+DROP POLICY IF EXISTS "Authenticated users can manage scans" ON storage.objects;
+CREATE POLICY "Authenticated users can manage scans"
+  ON storage.objects FOR ALL
+  USING (bucket_id = 'scans' AND auth.role() = 'authenticated')
+  WITH CHECK (bucket_id = 'scans' AND auth.role() = 'authenticated');
+
+-- ============================================================
+-- 7. Per-truck running fuel level ("Remaining Gallons" column).
+--    The paper sheet keeps a hand-computed running total per truck per day:
+--    row remaining = previous remaining (or the day's starting gallons)
+--    minus gallons pumped; tank fills / transfers-in add fuel back.
+--    (~/src/minuteman was checked per standing instruction: its fuel-farm
+--    module tracks FARM tanks via inches→gallons calibration tables and has
+--    no per-truck running total to copy, so this view is new logic.)
+--    The view derives the expected value from starting_gallons + the ordered
+--    rows and exposes the as-written value beside it, so the UI can show
+--    discrepancies instead of silently trusting either number.
+-- ============================================================
+CREATE OR REPLACE VIEW truck_sheet_running_totals AS
+SELECT
+  r.id                AS reading_id,
+  r.truck_sheet_id,
+  s.sheet_date,
+  s.truck_number,
+  r.line_number,
+  r.reading_type,
+  r.gallons_pumped,
+  r.gallons_remaining AS gallons_remaining_written,
+  s.starting_gallons
+    + SUM(
+        CASE
+          WHEN r.reading_type IN ('tank_fill', 'transfer_in') THEN COALESCE(r.gallons_pumped, 0)
+          ELSE -COALESCE(r.gallons_pumped, 0)
+        END
+      ) OVER (
+        PARTITION BY r.truck_sheet_id
+        ORDER BY r.line_number
+        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+      )               AS gallons_remaining_computed
+FROM truck_meter_readings r
+JOIN truck_sheets s ON s.id = r.truck_sheet_id;
+
+COMMENT ON VIEW truck_sheet_running_totals IS 'Derived per-truck running fuel level per sheet row, alongside the hand-written value, for discrepancy checks.';
+
+-- ============================================================
+-- 8. RLS (house style: authenticated users manage all)
+-- ============================================================
+ALTER TABLE fuel_transaction_tank_readings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scanned_documents              ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Authenticated users can manage tank readings" ON fuel_transaction_tank_readings;
+CREATE POLICY "Authenticated users can manage tank readings"
+  ON fuel_transaction_tank_readings FOR ALL
+  USING (auth.role() = 'authenticated');
+
+DROP POLICY IF EXISTS "Authenticated users can manage scanned documents" ON scanned_documents;
+CREATE POLICY "Authenticated users can manage scanned documents"
+  ON scanned_documents FOR ALL
+  USING (auth.role() = 'authenticated');
+
+-- ============================================================
+-- NOT done here (documented follow-ups — see the design doc):
+--   * No backfill synthesizing fuel_transaction rows for already-billed
+--     truck_meter_readings: existing lines keep truck_meter_reading_id and
+--     remain valid; new billing writes fuel_transaction_id.
+--   * No OCR route for invoice slips yet (second document layout) — schema
+--     and storage above already accept them.
+--   * AI chatbot intake is future-phase only: createTransaction() in
+--     frontend/repositories/transactions.repo.ts stays the single clean
+--     entry point a chatbot tool-call would use.
+--
+-- After running, regenerate types:
+--   cd frontend && npx supabase gen types typescript --schema public --project-id qkuhvlrdidhumyyxokil > types/database.ts
+-- ============================================================

--- a/frontend/supabase/config.toml
+++ b/frontend/supabase/config.toml
@@ -113,7 +113,7 @@ port = 54324
 # sender_name = "Admin"
 
 [storage]
-enabled = false
+enabled = true
 # The maximum file size allowed (e.g. "5MB", "500KB").
 file_size_limit = "50MiB"
 

--- a/frontend/supabase/migrations/20260703000300_fuel_invoicing_workflow.sql
+++ b/frontend/supabase/migrations/20260703000300_fuel_invoicing_workflow.sql
@@ -1,0 +1,106 @@
+-- Test-schema mirror of frontend/scripts/fuel-invoicing-workflow-schema.sql
+-- (dispatch ↔ truck-sheet ↔ invoicing linkage). Keep the two in sync — the
+-- repository integration tests exist to catch drift between the repos,
+-- frontend/types/database.ts, and this schema.
+--
+-- Differences from the production script (consistent with the other test
+-- migrations): serial int PKs, no RLS/policies, no COMMENTs, no backfill
+-- (the test DB starts empty).
+
+-- 1. fuel_transaction dispatch-time fields
+alter table fuel_transaction rename column fuel_order_text to fuel_request;
+alter table fuel_transaction
+  add column gallons_requested numeric,
+  add column gallons_delivered numeric,
+  add column customer_name text;
+
+-- 2. scan-reconciliation link (async, nullable, intentionally non-unique:
+--    one fueling can span front+rear register rows)
+alter table truck_meter_readings
+  add column fuel_transaction_id integer references fuel_transaction(id) on delete set null;
+
+-- 3. per-tank before/after readings (airline fuelings; free-form position)
+create table fuel_transaction_tank_readings (
+  id serial primary key,
+  fuel_transaction_id integer not null references fuel_transaction(id) on delete cascade,
+  tank_position text not null check (tank_position <> ''),
+  reading_before numeric,
+  reading_after numeric,
+  reading_unit text not null default 'lbs' check (reading_unit in ('lbs','gal','kg')),
+  created_at timestamptz not null default now(),
+  unique (fuel_transaction_id, tank_position)
+);
+
+-- 4. billing link: a fuel_transaction is billed at most once
+alter table invoice_line_items
+  add column fuel_transaction_id integer references fuel_transaction(id) on delete restrict;
+
+create unique index uq_invoice_line_items_fuel_transaction
+  on invoice_line_items(fuel_transaction_id)
+  where fuel_transaction_id is not null;
+
+-- 5. invoice-number regimes + paper-book pickup state
+alter table invoices
+  add column number_source text not null default 'live' check (number_source in ('live','paper_book')),
+  add column accounting_picked_up_at timestamptz;
+
+-- 6. scanned document originals (both paper document types)
+create table scanned_documents (
+  id serial primary key,
+  doc_type text not null check (doc_type in ('truck_sheet','invoice_slip')),
+  storage_bucket text not null default 'scans',
+  storage_path text not null unique,
+  original_filename text not null,
+  content_type text not null,
+  byte_size bigint,
+  page_number integer,
+  truck_sheet_id integer references truck_sheets(id) on delete set null,
+  invoice_id integer references invoices(id) on delete set null,
+  uploaded_by uuid,
+  notes text,
+  created_at timestamptz not null default now()
+);
+
+-- private bucket for scan uploads. Guarded: only when the storage service is
+-- enabled (supabase/config.toml [storage]) — the storage schema doesn't exist
+-- otherwise and plain-Postgres CI targets shouldn't fail on it.
+do $$
+begin
+  if exists (
+    select 1 from information_schema.tables
+    where table_schema = 'storage' and table_name = 'buckets'
+  ) then
+    insert into storage.buckets (id, name, public)
+    values ('scans', 'scans', false)
+    on conflict (id) do nothing;
+  end if;
+end $$;
+
+-- 7. per-truck running fuel level, derived vs. as-written
+create or replace view truck_sheet_running_totals as
+select
+  r.id                as reading_id,
+  r.truck_sheet_id,
+  s.sheet_date,
+  s.truck_number,
+  r.line_number,
+  r.reading_type,
+  r.gallons_pumped,
+  r.gallons_remaining as gallons_remaining_written,
+  s.starting_gallons
+    + sum(
+        case
+          when r.reading_type in ('tank_fill', 'transfer_in') then coalesce(r.gallons_pumped, 0)
+          else -coalesce(r.gallons_pumped, 0)
+        end
+      ) over (
+        partition by r.truck_sheet_id
+        order by r.line_number
+        rows between unbounded preceding and current row
+      )               as gallons_remaining_computed
+from truck_meter_readings r
+join truck_sheets s on s.id = r.truck_sheet_id;
+
+grant all on fuel_transaction_tank_readings, scanned_documents to anon, authenticated, service_role;
+grant select on truck_sheet_running_totals to anon, authenticated, service_role;
+grant all on all sequences in schema public to anon, authenticated, service_role;

--- a/frontend/supabase/migrations/20260703000300_fuel_invoicing_workflow.sql
+++ b/frontend/supabase/migrations/20260703000300_fuel_invoicing_workflow.sql
@@ -19,17 +19,22 @@ alter table fuel_transaction
 alter table truck_meter_readings
   add column fuel_transaction_id integer references fuel_transaction(id) on delete set null;
 
--- 3. per-tank before/after readings (airline fuelings; free-form position)
-create table fuel_transaction_tank_readings (
-  id serial primary key,
-  fuel_transaction_id integer not null references fuel_transaction(id) on delete cascade,
-  tank_position text not null check (tank_position <> ''),
-  reading_before numeric,
-  reading_after numeric,
-  reading_unit text not null default 'lbs' check (reading_unit in ('lbs','gal','kg')),
-  created_at timestamptz not null default now(),
-  unique (fuel_transaction_id, tank_position)
-);
+-- 3. per-tank before/after readings (airline fuelings only): fixed columns
+--    on fuel_transaction, not a normalized per-position table — plain SQL
+--    (AVG/GROUP BY) needs to aggregate these directly for analytics later.
+--    center is a real tank on 737 (L/C/R); E175's L/R/T has no center tank,
+--    its "T" is the total reading, so center stays null there.
+alter table fuel_transaction
+  add column tank_reading_before_left numeric,
+  add column tank_reading_before_right numeric,
+  add column tank_reading_before_center numeric,
+  add column tank_reading_before_total numeric,
+  add column tank_reading_after_left numeric,
+  add column tank_reading_after_right numeric,
+  add column tank_reading_after_center numeric,
+  add column tank_reading_after_total numeric,
+  add column tank_reading_unit text not null default 'lbs'
+    check (tank_reading_unit in ('lbs','gal','kg'));
 
 -- 4. billing link: a fuel_transaction is billed at most once
 alter table invoice_line_items
@@ -101,6 +106,6 @@ select
 from truck_meter_readings r
 join truck_sheets s on s.id = r.truck_sheet_id;
 
-grant all on fuel_transaction_tank_readings, scanned_documents to anon, authenticated, service_role;
+grant all on scanned_documents to anon, authenticated, service_role;
 grant select on truck_sheet_running_totals to anon, authenticated, service_role;
 grant all on all sequences in schema public to anon, authenticated, service_role;

--- a/frontend/supabase/migrations/20260703000400_error_logging.sql
+++ b/frontend/supabase/migrations/20260703000400_error_logging.sql
@@ -1,0 +1,20 @@
+-- Test-schema mirror of frontend/scripts/error-logging-schema.sql.
+-- General-purpose observability table — not specific to invoicing. See that
+-- file for the full rationale (Docker-on-VPS deployment has no log
+-- aggregation; container stdout isn't queryable after the fact).
+
+create table app_error_log (
+  id serial primary key,
+  occurred_at timestamptz not null default now(),
+  category text not null,
+  error_code text not null,
+  message text not null,
+  detail text,
+  context jsonb,
+  user_id uuid,
+  source text,
+  created_at timestamptz not null default now()
+);
+
+grant all on app_error_log to anon, authenticated, service_role;
+grant all on all sequences in schema public to anon, authenticated, service_role;

--- a/frontend/tests/support/reset.ts
+++ b/frontend/tests/support/reset.ts
@@ -5,8 +5,8 @@ import { TEST_SUPABASE_URL, assertSafeTestTarget } from './client'
 // Deletion order: children before parents, so FK constraints never block a wipe.
 // Keep this in sync with frontend/supabase/migrations/*.sql.
 const RESET_ORDER: Array<{ table: keyof Database['public']['Tables']; pk: string }> = [
+  { table: 'app_error_log', pk: 'id' },
   { table: 'scanned_documents', pk: 'id' },
-  { table: 'fuel_transaction_tank_readings', pk: 'id' },
   { table: 'invoice_fuel_readings', pk: 'id' },
   { table: 'invoice_line_items', pk: 'id' },
   { table: 'invoices', pk: 'id' },

--- a/frontend/tests/support/reset.ts
+++ b/frontend/tests/support/reset.ts
@@ -5,6 +5,8 @@ import { TEST_SUPABASE_URL, assertSafeTestTarget } from './client'
 // Deletion order: children before parents, so FK constraints never block a wipe.
 // Keep this in sync with frontend/supabase/migrations/*.sql.
 const RESET_ORDER: Array<{ table: keyof Database['public']['Tables']; pk: string }> = [
+  { table: 'scanned_documents', pk: 'id' },
+  { table: 'fuel_transaction_tank_readings', pk: 'id' },
   { table: 'invoice_fuel_readings', pk: 'id' },
   { table: 'invoice_line_items', pk: 'id' },
   { table: 'invoices', pk: 'id' },

--- a/frontend/types/database.ts
+++ b/frontend/types/database.ts
@@ -537,6 +537,15 @@ export type Database = {
           gallons_requested: string | null
           gallons_delivered: string | null
           customer_name: string | null
+          tank_reading_before_left: string | null
+          tank_reading_before_right: string | null
+          tank_reading_before_center: string | null
+          tank_reading_before_total: string | null
+          tank_reading_after_left: string | null
+          tank_reading_after_right: string | null
+          tank_reading_after_center: string | null
+          tank_reading_after_total: string | null
+          tank_reading_unit: 'lbs' | 'gal' | 'kg'
           created_at: string
           modified_at: string
           assigned_fueler_id: number | null
@@ -564,6 +573,15 @@ export type Database = {
           gallons_requested?: number | string | null
           gallons_delivered?: number | string | null
           customer_name?: string | null
+          tank_reading_before_left?: number | string | null
+          tank_reading_before_right?: number | string | null
+          tank_reading_before_center?: number | string | null
+          tank_reading_before_total?: number | string | null
+          tank_reading_after_left?: number | string | null
+          tank_reading_after_right?: number | string | null
+          tank_reading_after_center?: number | string | null
+          tank_reading_after_total?: number | string | null
+          tank_reading_unit?: 'lbs' | 'gal' | 'kg'
         }
         Update: Partial<
           Database['public']['Tables']['fuel_transaction']['Insert']
@@ -1147,37 +1165,6 @@ export type Database = {
           },
         ]
       }
-      fuel_transaction_tank_readings: {
-        Row: {
-          id: number
-          fuel_transaction_id: number
-          tank_position: string
-          reading_before: number | null
-          reading_after: number | null
-          reading_unit: 'lbs' | 'gal' | 'kg'
-          created_at: string
-        }
-        Insert: {
-          id?: number
-          fuel_transaction_id: number
-          tank_position: string
-          reading_before?: number | null
-          reading_after?: number | null
-          reading_unit?: 'lbs' | 'gal' | 'kg'
-        }
-        Update: Partial<
-          Database['public']['Tables']['fuel_transaction_tank_readings']['Insert']
-        >
-        Relationships: [
-          {
-            foreignKeyName: 'fuel_transaction_tank_readings_fuel_transaction_id_fkey'
-            columns: ['fuel_transaction_id']
-            isOneToOne: false
-            referencedRelation: 'fuel_transaction'
-            referencedColumns: ['id']
-          },
-        ]
-      }
       scanned_documents: {
         Row: {
           id: number
@@ -1225,6 +1212,33 @@ export type Database = {
             referencedColumns: ['id']
           },
         ]
+      }
+      app_error_log: {
+        Row: {
+          id: number
+          occurred_at: string
+          category: string
+          error_code: string
+          message: string
+          detail: string | null
+          context: Record<string, unknown> | null
+          user_id: string | null
+          source: string | null
+          created_at: string
+        }
+        Insert: {
+          id?: number
+          occurred_at?: string
+          category: string
+          error_code: string
+          message: string
+          detail?: string | null
+          context?: Record<string, unknown> | null
+          user_id?: string | null
+          source?: string | null
+        }
+        Update: Partial<Database['public']['Tables']['app_error_log']['Insert']>
+        Relationships: []
       }
     }
     // NOTE: the truck_sheet_running_totals view exists in the database (see

--- a/frontend/types/database.ts
+++ b/frontend/types/database.ts
@@ -533,7 +533,10 @@ export type Database = {
           fuel_type: 'jet_a' | 'jet_a_plus' | 'avgas' | null
           source: 'qt' | 'flight_card' | 'manual'
           ordered_by_id: number | null
-          fuel_order_text: string | null
+          fuel_request: string | null
+          gallons_requested: string | null
+          gallons_delivered: string | null
+          customer_name: string | null
           created_at: string
           modified_at: string
           assigned_fueler_id: number | null
@@ -557,7 +560,10 @@ export type Database = {
           fuel_type?: 'jet_a' | 'jet_a_plus' | 'avgas' | null
           source?: 'qt' | 'flight_card' | 'manual'
           ordered_by_id?: number | null
-          fuel_order_text?: string | null
+          fuel_request?: string | null
+          gallons_requested?: number | string | null
+          gallons_delivered?: number | string | null
+          customer_name?: string | null
         }
         Update: Partial<
           Database['public']['Tables']['fuel_transaction']['Insert']
@@ -817,6 +823,7 @@ export type Database = {
           invoice_number: string | null
           service_time: string | null
           flight_id: number | null
+          fuel_transaction_id: number | null
           notes: string | null
           created_at: string
         }
@@ -840,6 +847,7 @@ export type Database = {
           invoice_number?: string | null
           service_time?: string | null
           flight_id?: number | null
+          fuel_transaction_id?: number | null
           notes?: string | null
         }
         Update: Partial<Database['public']['Tables']['truck_meter_readings']['Insert']>
@@ -849,6 +857,13 @@ export type Database = {
             columns: ['truck_sheet_id']
             isOneToOne: false
             referencedRelation: 'truck_sheets'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'truck_meter_readings_fuel_transaction_id_fkey'
+            columns: ['fuel_transaction_id']
+            isOneToOne: false
+            referencedRelation: 'fuel_transaction'
             referencedColumns: ['id']
           },
         ]
@@ -991,6 +1006,8 @@ export type Database = {
           salesman_initials: string | null
           total: number
           notes: string | null
+          number_source: 'live' | 'paper_book'
+          accounting_picked_up_at: string | null
           created_at: string
           updated_at: string
         }
@@ -1013,6 +1030,8 @@ export type Database = {
           salesman_initials?: string | null
           total?: number
           notes?: string | null
+          number_source?: 'live' | 'paper_book'
+          accounting_picked_up_at?: string | null
           updated_at?: string
         }
         Update: Partial<Database['public']['Tables']['invoices']['Insert']>
@@ -1041,6 +1060,7 @@ export type Database = {
           item_type: 'fuel' | 'service' | 'fee' | 'product'
           product_id: number | null
           truck_meter_reading_id: number | null
+          fuel_transaction_id: number | null
           description: string
           quantity: number
           unit_price: number
@@ -1058,6 +1078,7 @@ export type Database = {
           item_type?: 'fuel' | 'service' | 'fee' | 'product'
           product_id?: number | null
           truck_meter_reading_id?: number | null
+          fuel_transaction_id?: number | null
           description: string
           quantity?: number
           unit_price?: number
@@ -1090,6 +1111,13 @@ export type Database = {
             referencedRelation: 'truck_meter_readings'
             referencedColumns: ['id']
           },
+          {
+            foreignKeyName: 'invoice_line_items_fuel_transaction_id_fkey'
+            columns: ['fuel_transaction_id']
+            isOneToOne: false
+            referencedRelation: 'fuel_transaction'
+            referencedColumns: ['id']
+          },
         ]
       }
       invoice_fuel_readings: {
@@ -1119,7 +1147,92 @@ export type Database = {
           },
         ]
       }
+      fuel_transaction_tank_readings: {
+        Row: {
+          id: number
+          fuel_transaction_id: number
+          tank_position: string
+          reading_before: number | null
+          reading_after: number | null
+          reading_unit: 'lbs' | 'gal' | 'kg'
+          created_at: string
+        }
+        Insert: {
+          id?: number
+          fuel_transaction_id: number
+          tank_position: string
+          reading_before?: number | null
+          reading_after?: number | null
+          reading_unit?: 'lbs' | 'gal' | 'kg'
+        }
+        Update: Partial<
+          Database['public']['Tables']['fuel_transaction_tank_readings']['Insert']
+        >
+        Relationships: [
+          {
+            foreignKeyName: 'fuel_transaction_tank_readings_fuel_transaction_id_fkey'
+            columns: ['fuel_transaction_id']
+            isOneToOne: false
+            referencedRelation: 'fuel_transaction'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      scanned_documents: {
+        Row: {
+          id: number
+          doc_type: 'truck_sheet' | 'invoice_slip'
+          storage_bucket: string
+          storage_path: string
+          original_filename: string
+          content_type: string
+          byte_size: number | null
+          page_number: number | null
+          truck_sheet_id: number | null
+          invoice_id: number | null
+          uploaded_by: string | null
+          notes: string | null
+          created_at: string
+        }
+        Insert: {
+          id?: number
+          doc_type: 'truck_sheet' | 'invoice_slip'
+          storage_bucket?: string
+          storage_path: string
+          original_filename: string
+          content_type: string
+          byte_size?: number | null
+          page_number?: number | null
+          truck_sheet_id?: number | null
+          invoice_id?: number | null
+          uploaded_by?: string | null
+          notes?: string | null
+        }
+        Update: Partial<Database['public']['Tables']['scanned_documents']['Insert']>
+        Relationships: [
+          {
+            foreignKeyName: 'scanned_documents_truck_sheet_id_fkey'
+            columns: ['truck_sheet_id']
+            isOneToOne: false
+            referencedRelation: 'truck_sheets'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'scanned_documents_invoice_id_fkey'
+            columns: ['invoice_id']
+            isOneToOne: false
+            referencedRelation: 'invoices'
+            referencedColumns: ['id']
+          },
+        ]
+      }
     }
+    // NOTE: the truck_sheet_running_totals view exists in the database (see
+    // scripts/fuel-invoicing-workflow-schema.sql) but is intentionally NOT
+    // declared here yet: adding a non-empty Views map flips supabase-js into
+    // strict schema typing for every existing query and surfaces unrelated
+    // embed-hint errors across the repos. Declare it (as TruckSheetRunningTotalRow
+    // below) when a repo actually queries it.
     Views: Record<string, never>
     Functions: {
       complete_certification: {
@@ -1147,3 +1260,20 @@ export type TablesInsert<T extends keyof Database['public']['Tables']> =
 
 export type TablesUpdate<T extends keyof Database['public']['Tables']> =
   Database['public']['Tables'][T]['Update']
+
+/**
+ * Row shape of the truck_sheet_running_totals view (per-truck running fuel
+ * level derived from the ordered sheet rows, beside the hand-written value).
+ * Kept out of Database['public']['Views'] for now — see the note there.
+ */
+export interface TruckSheetRunningTotalRow {
+  reading_id: number
+  truck_sheet_id: number
+  sheet_date: string
+  truck_number: string
+  line_number: number
+  reading_type: 'fueling' | 'tank_fill' | 'transfer_in' | 'transfer_out' | 'other'
+  gallons_pumped: number | null
+  gallons_remaining_written: number | null
+  gallons_remaining_computed: number | null
+}


### PR DESCRIPTION
## Not a routine merge-wave PR

This is an **architecture proposal** for the schema and workflow that connect fuel dispatch, scanned paper truck sheets, and invoicing — the design question open since PR #15. It governs **real billing correctness**, so please review the judgment calls below before merging. The production migrations (`frontend/scripts/fuel-invoicing-workflow-schema.sql`, `frontend/scripts/error-logging-schema.sql`) have **not** been run against any live database.

Full design doc with Mermaid ER + sequence diagrams: `docs/architecture/fuel-invoicing-workflow.md`.

## What it models (from the real ramp workflow)

- `fuel_transaction` = the live dispatch record (radioed in, **no meter numbers** at creation — just tail, customer, gallons, free-form `fuel_request`).
- `truck_meter_readings` rows arrive later from scanned sheets and link back via a nullable, async-populated `fuel_transaction_id`.
- A fueling becomes exactly **one** invoice line item (`invoice_line_items.fuel_transaction_id`, partial unique index = double-billing is a DB error); services/fluids/fees are separate lines on the same invoice.
- Two invoice-number regimes: `number_source='live'` (dash format `26-3330`, issued immediately over the radio) vs `'paper_book'` (pre-printed 5-digit serial `21483`, airline books; `accounting_picked_up_at IS NULL` = pending the midday box pickup).
- Optional per-tank before/after readings — **fixed columns** on `fuel_transaction` (`tank_reading_{before,after}_{left,right,center,total}` + `tank_reading_unit`), not a normalized side table (see "Follow-up #1" below for why).
- Original scans of **both** paper document types now persist (private `scans` Storage bucket + `scanned_documents`; truck-sheet import uploads originals best-effort). Invoice-slip OCR ingestion is designed in the doc but not built.
- `truck_sheet_running_totals` view: derived per-truck running fuel level beside the hand-written value. `~/src/minuteman` was checked first per standing instruction — it only has farm-tank calibration logic, nothing truck-level to copy.
- Everything nullable/linked-later by design: inconsistent scanning is the expected norm, not an error.
- AI chatbot intake: **future phase only**, documented; `createTransaction()` stays the clean callable entry point.
- Known Postgres constraint violations (double-billing, deleting a billed transaction) are now translated into clear, user-facing messages and logged to a durable, queryable error log — see "Follow-up #2".

## Follow-up #1: tank readings revised to fixed columns

Per Ted's review, per-tank readings were changed from a normalized `fuel_transaction_tank_readings` side table (free-form `tank_position`) to **eight fixed, nullable columns directly on `fuel_transaction`**. Reasoning: Ted wants to run analytics later (e.g. average fuel taken by a given airline/aircraft type) — fixed columns aggregate directly with plain SQL (`AVG`/`GROUP BY`); a normalized per-position table would need a pivot on every such query. It's also a better structural fit: this is strictly 1:1 data (one reading set per fueling, never one-to-many).

737's center tank is real; E175's L/R/T "T" is almost certainly the **totalizer**, not a third tank — `tank_reading_before/after_center` simply stays null for E175 fuelings. `findTankReadings`/`updateTankReadings` in `transactions.repo.ts` read/write the group as one unit. Tradeoff accepted explicitly: a genuinely new tank layout beyond left/right/center/total would need a migration, where the free-form table wouldn't have.

## Follow-up #2: constraint-violation handling + general-purpose error logging

Two more asks from review, addressed together since the second builds on the first:

1. **Graceful constraint handling.** The new unique index (double-billing) and `ON DELETE RESTRICT` (deleting a billed transaction) previously surfaced as raw Postgres errors (`23505`/`23503`) all the way to the UI. `lib/db-errors.ts`'s `handleWriteError()` now translates known constraint violations into a `ConstraintViolationError` with a clear `.message` ("This fueling has already been added to another invoice.", "This fueling has already been billed to an invoice — void the invoice before deleting it."), wired into `invoices.repo.ts`'s `createInvoice` and `transactions.repo.ts`'s `deleteTransaction`. `app/fuel-dispatch/page.tsx`'s delete handler previously had **no error handling at all** (an unhandled promise rejection with zero user feedback) — it now catches and shows a destructive toast with the friendly message.
2. **Durable, queryable error logging** — general-purpose, not invoicing-specific. Deployment is Docker on a VPS with no log aggregation, so container stdout isn't queryable after the fact. `lib/error-logging.ts`'s `logAppError()` persists structured entries (timestamp, category, code, human message, technical detail/stack — never shown to end users, entity-id context, user id when available from the session) to a new `app_error_log` table, always echoing to console first for local/dev visibility. It never throws — a logging failure must not break the caller's actual error handling. `handleWriteError()` is its first real caller, but the module is designed for any part of the app to adopt later.
   - Explicitly **not built**: any chatbot/support-tool use of this log data (Ted's long-term idea). Entries are just structured/queryable enough ("what happened around timestamp X for user Y?") that something could reasonably query them later.

## Judgment calls that need reviewer eyes

1. **Renamed `fuel_order_text` → `fuel_request`** (Ted's specified name; the dispatch UI already labeled it "Fuel Request"). Guarded rename in the migration + UI cascade. If anything external reads the old column name, this breaks it.
2. **Added `customer_name` to `fuel_transaction`** — not explicitly requested, but the radioed call includes the customer and the "not yet invoiced" queue needs someone to bill. Cut it if dispatch should stay lean.
3. **Reading→transaction link is non-unique** so a big fueling can span front + rear register rows; double-billing is prevented at the line-item level instead. Alternative (strict 1:1) is a one-line index change.
4. **`ON DELETE RESTRICT`** on billed transactions: deleting a billed dispatch record errors until the invoice is voided. Chose billing integrity over delete convenience — now with a friendly message instead of a raw Postgres error (see Follow-up #2).
5. **Backfill policy**: existing invoices get `number_source` classified by number shape (`^\d{5}$` = paper book) and non-draft book invoices get `accounting_picked_up_at = created_at`. Existing billed meter readings do **not** get synthetic fuel_transactions — old lines stay valid on `truck_meter_reading_id` alone. If synthesizing transactions for history is wanted, that's a follow-up.
6. **Pending pickup is derived state** (`number_source` + `accounting_picked_up_at`), not a new `status` enum value — keeps draft/open/paid/void untouched.
7. **Legacy `quantity_gallons` untouched** next to new `gallons_requested`/`gallons_delivered` — three gallon-ish columns is admittedly awkward; consolidation deferred until QT-era usage is confirmed dead.
8. **`truck_sheet_running_totals` is not in the typed client yet**: declaring a non-empty `Views` map flips supabase-js into strict typing and surfaces pre-existing embed-hint errors in unrelated repos (`certifications.repo.ts`, `transactions.repo.ts`). Documented in `types/database.ts`; row type exported as `TruckSheetRunningTotalRow`.
9. **Local test stack now runs the Storage service** (`supabase/config.toml [storage] enabled = true`) so the scan upload path is integration-tested for real.
10. **Tank readings are fixed columns, not free-form** (superseded the original design — see Follow-up #1). A future aircraft layout beyond left/right/center/total needs a migration.
11. **`app_error_log` RLS follows house style** (any authenticated user can read/write all rows) rather than restricting reads to an admin/support role — there's no PII beyond `user_id`, and the existing roles/`module_permissions` system doesn't yet have an obvious "support" role to scope it to. Tightening this is a reasonable, non-blocking follow-up.
12. **Left untouched, out of scope**: `invoices.invoice_number`'s unique constraint predates this PR and has a pre-existing prod/test-schema drift — it's declared `UNIQUE` in `scripts/invoicing-schema.sql` but not in the local test migration (`supabase/migrations/20260703000100_invoicing_v2_schema.sql`), so it can't currently be exercised/verified against the local stack. `fuel-ticket-sheet.tsx` still has its own pre-existing string-matching workaround for this specific constraint (`message.includes('duplicate') && message.includes('invoice_number')`) — not folded into the new `handleWriteError` mechanism, since that would mean asserting behavior against an untested code path. Worth fixing as its own follow-up.

## Verification

- Both production schema scripts (`fuel-invoicing-workflow-schema.sql`, `error-logging-schema.sql`) applied **twice each** (idempotency) against a scratch database in the local container with stub `auth`/`storage` schemas + the mirrored prerequisite tables — clean every time. Running-totals view math checked against a seeded sheet (start 5000 → fuel 34.2 → tank fill +3000 → fuel 1200 reproduces the hand-written column exactly). Confirmed the fixed tank-reading columns land correctly via `\d fuel_transaction`.
- `tsc --noEmit` clean.
- `pnpm test` (full suite): **130/130 pass** (19 files) — up from 115/17, including:
  - `lib/__tests__/error-logging.test.ts` — persists full structured entries, honors an explicit `userId` vs. auto-deriving from the session, defaults optional fields to null, and **never throws even when the underlying persistence write itself fails** (forced via an invalid UUID).
  - `lib/__tests__/db-errors.test.ts` — translates known constraints to friendly messages, falls back to a default (or caller-supplied) message for unmapped constraints, recognizes unique/FK/check violations, passes through unrelated Postgres errors (e.g. not-null violations) unchanged, and logs every handled error with the correct category.
  - `fuel-invoicing-workflow.repo.test.ts` updated: double-billing and RESTRICT-delete now assert the translated `ConstraintViolationError` (name/sqlCode/constraintName/message) **and** that a matching `app_error_log` row was written with the right category/code/context; tank-reading tests rewritten for the fixed-column shape (E175 center-stays-null, 737 real center tank, clearing back to null).
- Playwright e2e not run (needs the seeded app stack).
