### PR TITLE
fix(test): stop hardcoding TODAY in fuel-invoicing-workflow test fixture

### DIFF
--- a/frontend/repositories/__tests__/fuel-invoicing-workflow.repo.test.ts
+++ b/frontend/repositories/__tests__/fuel-invoicing-workflow.repo.test.ts
@@ -41,7 +41,7 @@ beforeEach(async () => {
   await resetDatabase(db)
 })
 
-const TODAY = '2026-07-03'
+const TODAY = new Date().toISOString().slice(0, 10)
 
 async function makeSheetWithReading(
   overrides: Partial<Parameters<typeof createTruckMeterReadings>[1][number]> = {}


### PR DESCRIPTION
The `TODAY` constant in `fuel-invoicing-workflow.repo.test.ts` was a fixed calendar-date string (`2026-07-03`) used to build a date-window query in `findMatchCandidates`. Fixture rows get `created_at = now()` from Postgres at insert time, so once real wall-clock time passed the hardcoded window's upper bound, every match-candidate assertion started failing with no code change involved — a ticking time bomb, not a real regression. Discovered while rebasing PR #34 onto current master.

Fix: compute `TODAY` from the actual current date so the fixture stays correct indefinitely. Verified 119/119 tests passing.