### PR TITLE
Invoice-slip OCR import + mixed-batch document intake

### DIFF
--- a/frontend/app/api/ocr/classify-document/__tests__/classify-document-normalize.test.ts
+++ b/frontend/app/api/ocr/classify-document/__tests__/classify-document-normalize.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeClassification } from '../route'
+
+describe('normalizeClassification', () => {
+  it('accepts a known doc_type as-is', () => {
+    expect(
+      normalizeClassification({
+        doc_type: 'truck_sheet',
+        notes: 'grid of rows'
+      })
+    ).toEqual({
+      doc_type: 'truck_sheet',
+      notes: 'grid of rows'
+    })
+    expect(normalizeClassification({ doc_type: 'invoice_slip' }).doc_type).toBe(
+      'invoice_slip'
+    )
+  })
+
+  it('falls back to unrecognized for any unknown/garbage value — never trusts the model blindly', () => {
+    expect(
+      normalizeClassification({ doc_type: 'something_else' }).doc_type
+    ).toBe('unrecognized')
+    expect(normalizeClassification({ doc_type: 123 }).doc_type).toBe(
+      'unrecognized'
+    )
+    expect(normalizeClassification({}).doc_type).toBe('unrecognized')
+  })
+
+  it('trims notes and defaults to empty string when absent', () => {
+    expect(
+      normalizeClassification({
+        doc_type: 'truck_sheet',
+        notes: '  looks clear  '
+      }).notes
+    ).toBe('looks clear')
+    expect(normalizeClassification({ doc_type: 'truck_sheet' }).notes).toBe('')
+  })
+})

--- a/frontend/app/api/ocr/classify-document/route.ts
+++ b/frontend/app/api/ocr/classify-document/route.ts
@@ -1,0 +1,174 @@
+import Anthropic from '@anthropic-ai/sdk'
+import { type NextRequest, NextResponse } from 'next/server'
+
+const client = new Anthropic() // reads ANTHROPIC_API_KEY from process.env
+
+/**
+ * Classifies an uploaded scan (image or PDF) as one of the two known FBO
+ * paper-document types before routing it to the matching extraction
+ * endpoint — see app/api/ocr/truck-sheet/route.ts and
+ * app/api/ocr/invoice-slip/route.ts.
+ *
+ * Judgment call (flagged in the PR): this reuses the SAME technique the
+ * truck-sheet route already uses to classify each row's reading_type — a
+ * single Claude vision call with no training data or separate model — rather
+ * than a purpose-trained classifier. Zero new infra, proven pattern already
+ * in production.
+ *
+ * Scope: classifies the FILE AS A WHOLE (a multi-page PDF is treated as one
+ * logical document spanning pages, matching how the truck-sheet route
+ * already treats a multi-page PDF as one sheet). A single PDF that
+ * genuinely interleaves multiple *different* documents (e.g. some pages a
+ * truck sheet, other pages an unrelated invoice slip) is not split
+ * automatically here — that page-range-splitting problem is out of scope
+ * for this pass and should be flagged if it turns out to be a real need.
+ */
+
+export type DocClassification = 'truck_sheet' | 'invoice_slip' | 'unrecognized'
+
+export interface ClassifyResult {
+  doc_type: DocClassification
+  notes: string
+}
+
+const CLASSIFY_PROMPT = `You are sorting scanned FBO (aviation fuel services) paperwork into exactly one of two known document types, or flagging it as unrecognized. The file may be a single photo or a multi-page PDF (if multi-page, judge it as ONE document spanning those pages, and only classify as "unrecognized" — not each page separately).
+
+TYPE "truck_sheet": a grid/table log, one row per fueling event, for ONE truck's whole shift. Look for: a title mentioning "Truck Sheet" and "Jet A" or "Avgas", header boxes for "Truck No.", "Gallons Down", front/rear meter starting numbers, and MANY handwritten rows below with columns like Customer, Tail Number, Aircraft Type, Meter Start, Meter End, Gallons Pumped, Prist, Line Tech initials, Invoice No.
+
+TYPE "invoice_slip": a single carbon-copy invoice-book page, one per fueling, usually for one specific aircraft/customer. Look for: an invoice-book layout (often says something like "Invoice" or a company name, e.g. "Minuteman Aviation"), a PRE-PRINTED serial number (often in red ink, exactly 5 digits) in a corner, and fields like "Aircraft No.", "Aircraft Type", "Date", "Name", "Address", a meter reading at stop, "less reading start", and "total gallons delivered". Unlike a truck sheet, this is NOT a multi-row grid — it documents a single fueling.
+
+TYPE "unrecognized": anything that is clearly neither of the above (blank page, unrelated paperwork, illegible scan, or a document you cannot confidently place in either category).
+
+Return ONLY a valid JSON object — no prose before or after:
+{
+  "doc_type": "truck_sheet|invoice_slip|unrecognized",
+  "notes": "one short sentence: what you saw and why, or any ambiguity (e.g. if the file looks like it mixes multiple different documents)"
+}`
+
+const VALID_TYPES: DocClassification[] = [
+  'truck_sheet',
+  'invoice_slip',
+  'unrecognized'
+]
+
+function str(v: unknown): string {
+  return v == null ? '' : String(v).trim()
+}
+
+/**
+ * Normalizes a raw parsed classification payload, defaulting anything
+ * outside the known enum to 'unrecognized' rather than trusting the model's
+ * exact string. Exported (pure, no network I/O) so it can be unit-tested —
+ * see __tests__/classify-document-normalize.test.ts.
+ */
+export function normalizeClassification(parsed: {
+  doc_type?: unknown
+  notes?: unknown
+}): ClassifyResult {
+  const docType = str(parsed.doc_type) as DocClassification
+  return {
+    doc_type: VALID_TYPES.includes(docType) ? docType : 'unrecognized',
+    notes: str(parsed.notes)
+  }
+}
+
+export async function POST(req: NextRequest) {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return NextResponse.json(
+      { error: 'ANTHROPIC_API_KEY not configured' },
+      { status: 500 }
+    )
+  }
+
+  let formData: FormData
+  try {
+    formData = await req.formData()
+  } catch {
+    return NextResponse.json({ error: 'Invalid form data' }, { status: 400 })
+  }
+
+  const file = formData.get('file') as File | null
+  if (!file) {
+    return NextResponse.json({ error: 'No file provided' }, { status: 400 })
+  }
+
+  const isPdf = file.type === 'application/pdf'
+  const isImage = file.type.startsWith('image/')
+  if (!isPdf && !isImage) {
+    return NextResponse.json(
+      { error: 'File must be an image (JPEG, PNG) or PDF' },
+      { status: 400 }
+    )
+  }
+
+  const bytes = await file.arrayBuffer()
+  const base64 = Buffer.from(bytes).toString('base64')
+
+  // biome-ignore lint/suspicious/noExplicitAny: SDK types for document blocks
+  const fileBlock: any = isPdf
+    ? {
+        type: 'document',
+        source: { type: 'base64', media_type: 'application/pdf', data: base64 }
+      }
+    : {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: file.type as
+            | 'image/jpeg'
+            | 'image/png'
+            | 'image/webp'
+            | 'image/gif',
+          data: base64
+        }
+      }
+
+  let message: Anthropic.Message
+  try {
+    message = await client.messages.create({
+      model: 'claude-opus-4-8',
+      max_tokens: 512,
+      messages: [
+        {
+          role: 'user',
+          content: [fileBlock, { type: 'text', text: CLASSIFY_PROMPT }]
+        }
+      ]
+    })
+  } catch (err) {
+    console.error('[OCR classify-document] Claude API error:', err)
+    return NextResponse.json(
+      {
+        error:
+          'Classification failed. Check ANTHROPIC_API_KEY and model availability.'
+      },
+      { status: 502 }
+    )
+  }
+
+  const rawText =
+    message.content[0]?.type === 'text' ? message.content[0].text : ''
+
+  const jsonMatch = rawText.match(/\{[\s\S]*\}/)
+  if (!jsonMatch) {
+    console.error('[OCR classify-document] No JSON in response:', rawText)
+    return NextResponse.json(
+      { error: 'Could not parse classification response', raw_text: rawText },
+      { status: 502 }
+    )
+  }
+
+  let parsed: { doc_type?: unknown; notes?: unknown }
+  try {
+    parsed = JSON.parse(jsonMatch[0])
+  } catch {
+    return NextResponse.json(
+      { error: 'Invalid JSON in classification response', raw_text: rawText },
+      { status: 502 }
+    )
+  }
+
+  const result: ClassifyResult = normalizeClassification(parsed)
+
+  return NextResponse.json(result)
+}

--- a/frontend/app/api/ocr/invoice-slip/__tests__/invoice-slip-normalize.test.ts
+++ b/frontend/app/api/ocr/invoice-slip/__tests__/invoice-slip-normalize.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeExtractedInvoiceSlip } from '../route'
+
+describe('normalizeExtractedInvoiceSlip', () => {
+  it('trims and uppercases identity fields, lowercases the tank unit', () => {
+    const result = normalizeExtractedInvoiceSlip({
+      invoice_number: ' 21483 ',
+      aircraft_no: 'n 116 fe',
+      aircraft_type: ' b737 ',
+      customer_name: ' Life Flight ',
+      tank_reading_unit: 'LBS'
+    })
+
+    expect(result.invoice_number).toBe('21483')
+    expect(result.aircraft_no).toBe('N116FE')
+    expect(result.aircraft_type).toBe('B737')
+    expect(result.customer_name).toBe('Life Flight')
+    expect(result.tank_reading_unit).toBe('lbs')
+  })
+
+  it('defaults every missing field to an empty string, and slip_date to null', () => {
+    const result = normalizeExtractedInvoiceSlip({})
+
+    expect(result.invoice_number).toBe('')
+    expect(result.slip_date).toBeNull()
+    expect(result.aircraft_no).toBe('')
+    expect(result.tank_reading_unit).toBe('')
+    expect(result.tank_reading_before_left).toBe('')
+    expect(result.notes).toBe('')
+  })
+
+  it('rejects an unrecognized tank_reading_unit rather than passing it through', () => {
+    const result = normalizeExtractedInvoiceSlip({
+      tank_reading_unit: 'gallons'
+    })
+    expect(result.tank_reading_unit).toBe('')
+  })
+
+  it('preserves a valid slip_date string', () => {
+    const result = normalizeExtractedInvoiceSlip({ slip_date: '2026-07-04' })
+    expect(result.slip_date).toBe('2026-07-04')
+  })
+
+  it('strips spaces and dashes from the tail number', () => {
+    const result = normalizeExtractedInvoiceSlip({ aircraft_no: 'N-116-FE' })
+    expect(result.aircraft_no).toBe('N116FE')
+  })
+})

--- a/frontend/app/api/ocr/invoice-slip/route.ts
+++ b/frontend/app/api/ocr/invoice-slip/route.ts
@@ -1,0 +1,226 @@
+import Anthropic from '@anthropic-ai/sdk'
+import { type NextRequest, NextResponse } from 'next/server'
+
+const client = new Anthropic() // reads ANTHROPIC_API_KEY from process.env
+
+/**
+ * OCR extraction for the second physical document type — the carbon-copy
+ * "invoice slip" (pre-printed invoice book, e.g. "MAI — Minuteman Aviation
+ * Inc"), used primarily for airline fuelings. Mirrors
+ * app/api/ocr/truck-sheet/route.ts: same Claude-vision-as-classifier
+ * pattern, same whole-file-as-one-document-block approach for PDFs (a
+ * multi-page PDF here is treated as one slip spanning pages, not a bag of
+ * unrelated pages — see docs/architecture/fuel-invoicing-workflow.md).
+ */
+
+export interface ExtractedInvoiceSlip {
+  invoice_number: string // pre-printed 5-digit red serial, e.g. "21483"
+  slip_date: string | null // "YYYY-MM-DD" if visible
+  aircraft_no: string // tail number
+  aircraft_type: string
+  customer_name: string // the slip's "Name" field
+  address: string
+  meter_start: string // "less reading start"
+  meter_stop: string // "meter reading at stop"
+  gallons_delivered: string // "total gallons delivered"
+  // Optional per-tank before/after readings, handwritten in the slip's
+  // description area for airline fuelings only (737: L/C/R, E175: L/R/T —
+  // "T" there is the totalizer, not a real center tank). Empty string when
+  // not present/visible.
+  tank_reading_unit: 'lbs' | 'gal' | ''
+  tank_reading_before_left: string
+  tank_reading_before_right: string
+  tank_reading_before_center: string
+  tank_reading_before_total: string
+  tank_reading_after_left: string
+  tank_reading_after_right: string
+  tank_reading_after_center: string
+  tank_reading_after_total: string
+  notes: string
+  raw_text?: string // for debugging
+}
+
+const EXTRACT_PROMPT = `This is a photo of a handwritten, carbon-copy FBO fuel invoice slip (a pre-printed page torn from an invoice book, used mainly to bill airlines for a single fueling). The photo may be rotated in any direction, including fully upside down — mentally reorient it before reading.
+
+FORM LAYOUT
+- A pre-printed serial invoice number, usually in RED ink, near the top or a corner — always exactly 5 digits (e.g. "21483", "21457"). This is the slip's permanent identity; extract it exactly as printed even if handwriting elsewhere is messy.
+- Header fields, hand-filled: "Aircraft No." (tail number), "Aircraft Type" (e.g. B737, E175), "Date", "Name" (the customer/airline, e.g. "Life Flight", "UA 5996"), "Address".
+- A meter/fuel block: a reading at the END of the fueling ("meter reading at stop"), a reading SUBTRACTED for the start ("less reading start"), and "total gallons delivered" (should equal stop minus start).
+- A free-form description/remarks area sometimes holds handwritten PER-TANK before/after readings for airline fuelings — look for something like "L", "R", "C" or "T" labels each paired with a before and after number, and a unit (lbs is most common; sometimes gal). 737s have three tanks: Left, Center, Right. E175s have Left, Right, and a Total (no center tank — its "T" is a totalizer, not a third tank). Only extract these if actually present; most GA slips have none.
+
+READING THE HANDWRITING
+- A small raised/trailing digit after a meter number is TENTHS, same convention as truck sheets: "108413⁴" → 108413.4.
+- Circled numbers are corrections/emphasis — prefer the circled value.
+- Ignore faint mirrored/bleed-through text from the carbon copy underneath, and ignore obviously blank slips.
+
+Return ONLY a valid JSON object — no prose before or after — in exactly this format (ALL numeric values as strings, empty string when not visible):
+{
+  "invoice_number": "5-digit red serial, exactly as printed",
+  "slip_date": "YYYY-MM-DD or null if not clearly visible",
+  "aircraft_no": "",
+  "aircraft_type": "",
+  "customer_name": "the Name field",
+  "address": "",
+  "meter_start": "",
+  "meter_stop": "",
+  "gallons_delivered": "",
+  "tank_reading_unit": "lbs|gal or empty if no tank readings present",
+  "tank_reading_before_left": "",
+  "tank_reading_before_right": "",
+  "tank_reading_before_center": "",
+  "tank_reading_before_total": "",
+  "tank_reading_after_left": "",
+  "tank_reading_after_right": "",
+  "tank_reading_after_center": "",
+  "tank_reading_after_total": "",
+  "notes": "anything unusual, else empty"
+}
+
+Rules:
+- Do not invent data that isn't on the slip.
+- Tail numbers: uppercase, no spaces/dashes (e.g. "N 116 FE" → "N116FE").
+- Sanity-check your own numbers: gallons_delivered should equal meter_stop − meter_start; if your reading fails that check, re-read the digits before answering. Note remaining discrepancies in "notes".
+- If the pre-printed serial number is not legible at all, leave invoice_number empty rather than guessing — this number is the sole link to accounting's paper-book pickup and must never be fabricated.`
+
+function str(v: unknown): string {
+  return v == null ? '' : String(v).trim()
+}
+
+/**
+ * Normalizes a raw parsed extraction payload into the well-typed shape.
+ * Exported (pure, no network I/O) so it can be unit-tested independently of
+ * the Claude API call — see __tests__/invoice-slip-normalize.test.ts.
+ */
+export function normalizeExtractedInvoiceSlip(
+  parsed: Record<string, unknown>
+): Omit<ExtractedInvoiceSlip, 'raw_text'> {
+  const tankUnit = str(parsed.tank_reading_unit).toLowerCase()
+  return {
+    invoice_number: str(parsed.invoice_number),
+    slip_date: parsed.slip_date ? str(parsed.slip_date) : null,
+    aircraft_no: str(parsed.aircraft_no).toUpperCase().replace(/[\s-]/g, ''),
+    aircraft_type: str(parsed.aircraft_type).toUpperCase(),
+    customer_name: str(parsed.customer_name),
+    address: str(parsed.address),
+    meter_start: str(parsed.meter_start),
+    meter_stop: str(parsed.meter_stop),
+    gallons_delivered: str(parsed.gallons_delivered),
+    tank_reading_unit:
+      tankUnit === 'lbs' || tankUnit === 'gal'
+        ? (tankUnit as 'lbs' | 'gal')
+        : '',
+    tank_reading_before_left: str(parsed.tank_reading_before_left),
+    tank_reading_before_right: str(parsed.tank_reading_before_right),
+    tank_reading_before_center: str(parsed.tank_reading_before_center),
+    tank_reading_before_total: str(parsed.tank_reading_before_total),
+    tank_reading_after_left: str(parsed.tank_reading_after_left),
+    tank_reading_after_right: str(parsed.tank_reading_after_right),
+    tank_reading_after_center: str(parsed.tank_reading_after_center),
+    tank_reading_after_total: str(parsed.tank_reading_after_total),
+    notes: str(parsed.notes)
+  }
+}
+
+export async function POST(req: NextRequest) {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return NextResponse.json(
+      { error: 'ANTHROPIC_API_KEY not configured' },
+      { status: 500 }
+    )
+  }
+
+  let formData: FormData
+  try {
+    formData = await req.formData()
+  } catch {
+    return NextResponse.json({ error: 'Invalid form data' }, { status: 400 })
+  }
+
+  const file = formData.get('file') as File | null
+  if (!file) {
+    return NextResponse.json({ error: 'No file provided' }, { status: 400 })
+  }
+
+  const isPdf = file.type === 'application/pdf'
+  const isImage = file.type.startsWith('image/')
+  if (!isPdf && !isImage) {
+    return NextResponse.json(
+      { error: 'File must be an image (JPEG, PNG) or PDF' },
+      { status: 400 }
+    )
+  }
+
+  const bytes = await file.arrayBuffer()
+  const base64 = Buffer.from(bytes).toString('base64')
+
+  // biome-ignore lint/suspicious/noExplicitAny: SDK types for document blocks
+  const fileBlock: any = isPdf
+    ? {
+        type: 'document',
+        source: { type: 'base64', media_type: 'application/pdf', data: base64 }
+      }
+    : {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: file.type as
+            | 'image/jpeg'
+            | 'image/png'
+            | 'image/webp'
+            | 'image/gif',
+          data: base64
+        }
+      }
+
+  let message: Anthropic.Message
+  try {
+    message = await client.messages.create({
+      model: 'claude-opus-4-8',
+      max_tokens: 4096,
+      messages: [
+        {
+          role: 'user',
+          content: [fileBlock, { type: 'text', text: EXTRACT_PROMPT }]
+        }
+      ]
+    })
+  } catch (err) {
+    console.error('[OCR invoice-slip] Claude API error:', err)
+    return NextResponse.json(
+      {
+        error:
+          'Extraction failed. Check ANTHROPIC_API_KEY and model availability.'
+      },
+      { status: 502 }
+    )
+  }
+
+  const rawText =
+    message.content[0]?.type === 'text' ? message.content[0].text : ''
+
+  const jsonMatch = rawText.match(/\{[\s\S]*\}/)
+  if (!jsonMatch) {
+    console.error('[OCR invoice-slip] No JSON in response:', rawText)
+    return NextResponse.json(
+      { error: 'Could not parse extraction response', raw_text: rawText },
+      { status: 502 }
+    )
+  }
+
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(jsonMatch[0])
+  } catch {
+    return NextResponse.json(
+      { error: 'Invalid JSON in extraction response', raw_text: rawText },
+      { status: 502 }
+    )
+  }
+
+  const result: ExtractedInvoiceSlip = {
+    ...normalizeExtractedInvoiceSlip(parsed),
+    raw_text: rawText
+  }
+
+  return NextResponse.json(result)
+}

--- a/frontend/app/document-intake/page.tsx
+++ b/frontend/app/document-intake/page.tsx
@@ -1,0 +1,457 @@
+'use client'
+
+import {
+  type IntakeProgress,
+  IntakeUpload
+} from '@/components/document-intake/intake-upload'
+import { InvoiceSlipReview } from '@/components/invoice-slips/invoice-slip-review'
+import { TruckSheetReview } from '@/components/truck-sheets/truck-sheet-review'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { useCustomers } from '@/hooks/use-customers'
+import {
+  type DocClassification,
+  useClassifyDocument
+} from '@/hooks/use-document-classify'
+import {
+  type ReviewInvoiceSlip,
+  toReviewSlip,
+  useInvoiceSlipCommit,
+  useInvoiceSlipExtract
+} from '@/hooks/use-invoice-slip-import'
+import { useSession } from '@/hooks/use-session'
+import {
+  type ExtractedTruckSheet,
+  type ReviewSheet,
+  mergeExtractions,
+  useTruckSheetCommit,
+  useTruckSheetExtract
+} from '@/hooks/use-truck-sheet-import'
+import { useFuelTrucks } from '@/hooks/use-truck-sheets'
+import { ErrorMessage } from '@/messages/error-message'
+import { SuccessMessage } from '@/messages/success-message'
+import { ArrowLeft, CheckCircle2, Loader2, Upload } from 'lucide-react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
+
+function todayIso() {
+  return new Date().toISOString().split('T')[0]
+}
+
+interface UnrecognizedEntry {
+  file: File
+  notes?: string
+  retrying: boolean
+  error?: string
+}
+
+export default function DocumentIntakePage() {
+  const { status } = useSession()
+  const router = useRouter()
+
+  const { mutateAsync: classify } = useClassifyDocument()
+  const { mutateAsync: extractTruckSheet } = useTruckSheetExtract()
+  const { mutateAsync: extractInvoiceSlip } = useInvoiceSlipExtract()
+  const { mutateAsync: commitTruckSheets, isPending: committingSheets } =
+    useTruckSheetCommit()
+  const { mutateAsync: commitInvoiceSlips, isPending: committingSlips } =
+    useInvoiceSlipCommit()
+  const { data: trucks = [] } = useFuelTrucks()
+  const { customers } = useCustomers()
+  const knownTruckNumbers = new Set(trucks.map((t) => t.equipment_id))
+
+  const [progress, setProgress] = useState<IntakeProgress[]>([])
+  const [processing, setProcessing] = useState(false)
+  const [processError, setProcessError] = useState<string | null>(null)
+
+  // Accumulated across every batch dropped in this session, so a second
+  // smaller drop doesn't wipe out an earlier one — Ted's whole week of
+  // backlog may not fit in a single browser file picker selection.
+  const truckSheetPagesRef = useRef<
+    { file: File; extraction: ExtractedTruckSheet }[]
+  >([])
+  const [sheets, setSheets] = useState<ReviewSheet[]>([])
+  const [slips, setSlips] = useState<ReviewInvoiceSlip[]>([])
+  const [unrecognized, setUnrecognized] = useState<UnrecognizedEntry[]>([])
+
+  const [sheetsImported, setSheetsImported] = useState<number | null>(null)
+  const [slipsImported, setSlipsImported] = useState<number | null>(null)
+  const [sheetsCommitError, setSheetsCommitError] = useState<string | null>(
+    null
+  )
+  const [slipsCommitError, setSlipsCommitError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/login')
+  }, [status, router])
+
+  async function processOne(file: File, idx: number) {
+    setProgress((prev) =>
+      prev.map((p, i) => (i === idx ? { ...p, status: 'classifying' } : p))
+    )
+
+    let docType: DocClassification
+    try {
+      const result = await classify(file)
+      docType = result.doc_type
+      setProgress((prev) =>
+        prev.map((p, i) =>
+          i === idx ? { ...p, status: 'extracting', docType } : p
+        )
+      )
+    } catch (err) {
+      setProgress((prev) =>
+        prev.map((p, i) =>
+          i === idx
+            ? { ...p, status: 'error', error: (err as Error).message }
+            : p
+        )
+      )
+      return
+    }
+
+    if (docType === 'unrecognized') {
+      setProgress((prev) =>
+        prev.map((p, i) =>
+          i === idx ? { ...p, status: 'unrecognized', docType } : p
+        )
+      )
+      setUnrecognized((prev) => [...prev, { file, retrying: false }])
+      return
+    }
+
+    try {
+      if (docType === 'truck_sheet') {
+        const extraction = await extractTruckSheet(file)
+        truckSheetPagesRef.current = [
+          ...truckSheetPagesRef.current,
+          { file, extraction }
+        ]
+        setProgress((prev) =>
+          prev.map((p, i) =>
+            i === idx
+              ? {
+                  ...p,
+                  status: 'done',
+                  detail: `Truck ${extraction.truck_number}`
+                }
+              : p
+          )
+        )
+      } else {
+        const extraction = await extractInvoiceSlip(file)
+        setSlips((prev) => [...prev, toReviewSlip(file, extraction)])
+        setProgress((prev) =>
+          prev.map((p, i) =>
+            i === idx
+              ? {
+                  ...p,
+                  status: 'done',
+                  detail: extraction.invoice_number || '(no serial read)'
+                }
+              : p
+          )
+        )
+      }
+    } catch (err) {
+      setProgress((prev) =>
+        prev.map((p, i) =>
+          i === idx
+            ? { ...p, status: 'error', error: (err as Error).message }
+            : p
+        )
+      )
+    }
+  }
+
+  async function handleFiles(files: File[]) {
+    setProcessing(true)
+    setProcessError(null)
+    const startIdx = progress.length
+    setProgress((prev) => [
+      ...prev,
+      ...files.map((f) => ({ name: f.name, status: 'queued' as const }))
+    ])
+
+    for (let i = 0; i < files.length; i++) {
+      await processOne(files[i], startIdx + i)
+    }
+
+    setSheets(
+      mergeExtractions(truckSheetPagesRef.current).map((sheet) => ({
+        ...sheet,
+        sheet_date: sheet.sheet_date || todayIso()
+      }))
+    )
+    setProcessing(false)
+  }
+
+  async function retryUnrecognized(
+    index: number,
+    docType: 'truck_sheet' | 'invoice_slip'
+  ) {
+    setUnrecognized((prev) =>
+      prev.map((u, i) =>
+        i === index ? { ...u, retrying: true, error: undefined } : u
+      )
+    )
+    const entry = unrecognized[index]
+    try {
+      if (docType === 'truck_sheet') {
+        const extraction = await extractTruckSheet(entry.file)
+        truckSheetPagesRef.current = [
+          ...truckSheetPagesRef.current,
+          { file: entry.file, extraction }
+        ]
+        setSheets(
+          mergeExtractions(truckSheetPagesRef.current).map((sheet) => ({
+            ...sheet,
+            sheet_date: sheet.sheet_date || todayIso()
+          }))
+        )
+      } else {
+        const extraction = await extractInvoiceSlip(entry.file)
+        setSlips((prev) => [...prev, toReviewSlip(entry.file, extraction)])
+      }
+      setUnrecognized((prev) => prev.filter((_, i) => i !== index))
+    } catch (err) {
+      setUnrecognized((prev) =>
+        prev.map((u, i) =>
+          i === index
+            ? { ...u, retrying: false, error: (err as Error).message }
+            : u
+        )
+      )
+    }
+  }
+
+  function discardUnrecognized(index: number) {
+    setUnrecognized((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  function updateSheet(updated: ReviewSheet) {
+    setSheets((prev) => prev.map((s) => (s.id === updated.id ? updated : s)))
+  }
+
+  function updateSlip(updated: ReviewInvoiceSlip) {
+    setSlips((prev) => prev.map((s) => (s.id === updated.id ? updated : s)))
+  }
+
+  async function handleImportSheets() {
+    setSheetsCommitError(null)
+    try {
+      const created = await commitTruckSheets(sheets)
+      setSheetsImported(created.length)
+      setSheets([])
+      truckSheetPagesRef.current = []
+    } catch (err) {
+      setSheetsCommitError((err as Error).message)
+    }
+  }
+
+  async function handleImportSlips() {
+    setSlipsCommitError(null)
+    try {
+      const created = await commitInvoiceSlips(slips)
+      setSlipsImported(created.length)
+      setSlips([])
+    } catch (err) {
+      setSlipsCommitError((err as Error).message)
+    }
+  }
+
+  const readySheets =
+    sheets.length > 0 &&
+    sheets.every((s) => s.truck_number && s.sheet_date && s.fuel_type)
+  const readySlips =
+    slips.length > 0 &&
+    slips.every((s) => s.invoice_number && s.aircraft_no && s.customer_name)
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+      <div>
+        <Link
+          href="/"
+          className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1"
+        >
+          <ArrowLeft className="w-4 h-4" /> Home
+        </Link>
+        <h1 className="text-2xl font-bold mt-2">Document Intake</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Drop truck sheets and invoice slips in any mix — multi-page PDFs or
+          individual photos. Each file is identified with AI, extracted, and
+          routed to the matching review queue below. Nothing here requires
+          all-or-nothing matching — unrecognized scans are flagged for manual
+          triage instead of being dropped or guessed at.
+        </p>
+      </div>
+
+      <IntakeUpload onFiles={handleFiles} files={progress} busy={processing} />
+
+      {processError && <ErrorMessage>{processError}</ErrorMessage>}
+
+      {unrecognized.length > 0 && (
+        <Card className="p-4 space-y-3">
+          <h2 className="font-semibold">
+            Needs manual triage ({unrecognized.length})
+          </h2>
+          <p className="text-xs text-muted-foreground">
+            These files couldn&apos;t be confidently classified. Pick the
+            correct type to extract them anyway, or discard.
+          </p>
+          <ul className="divide-y divide-border text-sm">
+            {unrecognized.map((entry, idx) => (
+              <li
+                key={`${entry.file.name}-${idx}`}
+                className="flex items-center gap-3 py-2"
+              >
+                <span className="truncate flex-1">{entry.file.name}</span>
+                {entry.error && (
+                  <span className="text-xs text-destructive">
+                    {entry.error}
+                  </span>
+                )}
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={entry.retrying}
+                  onClick={() => retryUnrecognized(idx, 'truck_sheet')}
+                >
+                  It&apos;s a truck sheet
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={entry.retrying}
+                  onClick={() => retryUnrecognized(idx, 'invoice_slip')}
+                >
+                  It&apos;s an invoice slip
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  disabled={entry.retrying}
+                  onClick={() => discardUnrecognized(idx)}
+                >
+                  Discard
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+
+      {sheetsImported != null && (
+        <SuccessMessage>
+          <span className="flex items-center gap-2">
+            <CheckCircle2 className="w-4 h-4" />
+            Imported {sheetsImported} truck sheet
+            {sheetsImported === 1 ? '' : 's'}.{' '}
+            <Link href="/truck-sheets" className="underline">
+              View the fuel truck logs
+            </Link>
+          </span>
+        </SuccessMessage>
+      )}
+      {slipsImported != null && (
+        <SuccessMessage>
+          <span className="flex items-center gap-2">
+            <CheckCircle2 className="w-4 h-4" />
+            Imported {slipsImported} invoice slip
+            {slipsImported === 1 ? '' : 's'} as drafts.{' '}
+            <Link href="/invoicing" className="underline">
+              View invoicing
+            </Link>
+          </span>
+        </SuccessMessage>
+      )}
+
+      {sheets.length > 0 && (
+        <div className="space-y-3">
+          <h2 className="font-semibold text-lg">
+            Truck sheets ({sheets.length})
+          </h2>
+          <div className="space-y-4">
+            {sheets.map((sheet) => (
+              <TruckSheetReview
+                key={sheet.id}
+                sheet={sheet}
+                knownTruckNumbers={knownTruckNumbers}
+                onChange={updateSheet}
+                onRemove={() =>
+                  setSheets((prev) => prev.filter((s) => s.id !== sheet.id))
+                }
+              />
+            ))}
+          </div>
+          {sheetsCommitError && (
+            <ErrorMessage>{sheetsCommitError}</ErrorMessage>
+          )}
+          <div className="flex items-center justify-end gap-3">
+            <Button
+              onClick={handleImportSheets}
+              disabled={!readySheets || committingSheets}
+            >
+              {committingSheets ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-1 animate-spin" /> Importing…
+                </>
+              ) : (
+                <>
+                  <Upload className="w-4 h-4 mr-1" /> Import {sheets.length}{' '}
+                  truck sheet
+                  {sheets.length === 1 ? '' : 's'}
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {slips.length > 0 && (
+        <div className="space-y-3">
+          <h2 className="font-semibold text-lg">
+            Invoice slips ({slips.length})
+          </h2>
+          <div className="space-y-4">
+            {slips.map((slip) => (
+              <InvoiceSlipReview
+                key={slip.id}
+                slip={slip}
+                customers={customers}
+                onChange={updateSlip}
+                onRemove={() =>
+                  setSlips((prev) => prev.filter((s) => s.id !== slip.id))
+                }
+              />
+            ))}
+          </div>
+          {slipsCommitError && <ErrorMessage>{slipsCommitError}</ErrorMessage>}
+          <div className="flex items-center justify-end gap-3 pb-8">
+            <span className="text-sm text-muted-foreground">
+              Imported as drafts — price per gallon isn&apos;t on the slip and
+              needs a final check
+            </span>
+            <Button
+              onClick={handleImportSlips}
+              disabled={!readySlips || committingSlips}
+            >
+              {committingSlips ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-1 animate-spin" /> Importing…
+                </>
+              ) : (
+                <>
+                  <Upload className="w-4 h-4 mr-1" /> Import {slips.length}{' '}
+                  invoice slip
+                  {slips.length === 1 ? '' : 's'}
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/document-intake/intake-upload.tsx
+++ b/frontend/components/document-intake/intake-upload.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import type { DocClassification } from '@/hooks/use-document-classify'
+import { cn } from '@/lib/utils'
+import {
+  AlertCircle,
+  CheckCircle2,
+  FileImage,
+  FileQuestion,
+  Loader2,
+  Upload
+} from 'lucide-react'
+import { useRef, useState } from 'react'
+
+export type IntakeStatus =
+  | 'queued'
+  | 'classifying'
+  | 'extracting'
+  | 'done'
+  | 'unrecognized'
+  | 'error'
+
+export interface IntakeProgress {
+  name: string
+  status: IntakeStatus
+  docType?: DocClassification
+  detail?: string
+  error?: string
+}
+
+interface IntakeUploadProps {
+  onFiles: (files: File[]) => void
+  files: IntakeProgress[]
+  busy: boolean
+}
+
+const ACCEPTED = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+  'application/pdf'
+]
+
+const STATUS_LABEL: Record<IntakeStatus, string> = {
+  queued: 'Queued',
+  classifying: 'Identifying document…',
+  extracting: 'Reading with AI…',
+  done: 'Extracted',
+  unrecognized: 'Not recognized — needs triage',
+  error: 'Failed'
+}
+
+const DOC_TYPE_LABEL: Record<DocClassification, string> = {
+  truck_sheet: 'Truck sheet',
+  invoice_slip: 'Invoice slip',
+  unrecognized: 'Unrecognized'
+}
+
+export function IntakeUpload({ onFiles, files, busy }: IntakeUploadProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [dragOver, setDragOver] = useState(false)
+
+  function handleFiles(list: FileList | null) {
+    if (!list) return
+    const picked = Array.from(list).filter((f) => ACCEPTED.includes(f.type))
+    if (picked.length > 0) onFiles(picked)
+  }
+
+  return (
+    <div className="space-y-3">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => !busy && inputRef.current?.click()}
+        onKeyDown={(e) =>
+          e.key === 'Enter' && !busy && inputRef.current?.click()
+        }
+        onDrop={(e) => {
+          e.preventDefault()
+          setDragOver(false)
+          if (!busy) handleFiles(e.dataTransfer.files)
+        }}
+        onDragOver={(e) => {
+          e.preventDefault()
+          setDragOver(true)
+        }}
+        onDragLeave={() => setDragOver(false)}
+        className={cn(
+          'border-2 border-dashed rounded-xl p-10 flex flex-col items-center gap-3 transition-colors',
+          busy ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+          dragOver
+            ? 'border-primary bg-primary/5'
+            : 'border-border hover:border-primary/50 hover:bg-muted/30'
+        )}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          accept={ACCEPTED.join(',')}
+          className="hidden"
+          onChange={(e) => {
+            handleFiles(e.target.files)
+            e.target.value = ''
+          }}
+        />
+        <div className="flex gap-3 text-muted-foreground">
+          <FileImage className="w-8 h-8" />
+          <Upload className="w-8 h-8" />
+        </div>
+        <div className="text-center">
+          <div className="font-semibold text-foreground">
+            Drop scanned truck sheets and invoice slips here — mix any
+            combination
+          </div>
+          <div className="text-sm text-muted-foreground mt-1">
+            Multi-page PDFs (a whole shift/day at once) or individual photos,
+            all at once — each file is identified automatically and routed to
+            the right review queue
+          </div>
+        </div>
+      </div>
+
+      {files.length > 0 && (
+        <ul className="rounded-lg border border-border divide-y divide-border text-sm max-h-96 overflow-y-auto">
+          {files.map((f, idx) => (
+            <li
+              key={`${f.name}-${idx}`}
+              className="flex items-center gap-3 px-3 py-2"
+            >
+              {(f.status === 'classifying' || f.status === 'extracting') && (
+                <Loader2 className="w-4 h-4 animate-spin text-primary shrink-0" />
+              )}
+              {f.status === 'queued' && (
+                <div className="w-4 h-4 rounded-full border-2 border-muted-foreground/40 shrink-0" />
+              )}
+              {f.status === 'done' && (
+                <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
+              )}
+              {f.status === 'unrecognized' && (
+                <FileQuestion className="w-4 h-4 text-amber-400 shrink-0" />
+              )}
+              {f.status === 'error' && (
+                <AlertCircle className="w-4 h-4 text-destructive shrink-0" />
+              )}
+              <span className="truncate flex-1">{f.name}</span>
+              {f.docType && f.status !== 'unrecognized' && (
+                <span className="text-xs font-mono text-muted-foreground">
+                  {DOC_TYPE_LABEL[f.docType]}
+                </span>
+              )}
+              {f.detail && f.status === 'done' && (
+                <span className="text-xs font-mono text-muted-foreground">
+                  {f.detail}
+                </span>
+              )}
+              {f.status === 'error' && f.error && (
+                <span className="text-xs text-destructive truncate max-w-[16rem]">
+                  {f.error}
+                </span>
+              )}
+              {(f.status === 'classifying' || f.status === 'extracting') && (
+                <span className="text-xs text-muted-foreground">
+                  {STATUS_LABEL[f.status]}
+                </span>
+              )}
+              {f.status === 'unrecognized' && (
+                <span className="text-xs text-amber-400">
+                  {STATUS_LABEL[f.status]}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/invoice-slips/__tests__/slip-validation.test.ts
+++ b/frontend/components/invoice-slips/__tests__/slip-validation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { validateSlipMeter } from '../slip-validation'
+
+describe('validateSlipMeter', () => {
+  it('returns null when the meter math checks out', () => {
+    expect(
+      validateSlipMeter({
+        meter_start: 1000,
+        meter_stop: 1300,
+        gallons_delivered: 300
+      })
+    ).toBeNull()
+  })
+
+  it('tolerates small rounding differences (<= 1 gal)', () => {
+    expect(
+      validateSlipMeter({
+        meter_start: 1000,
+        meter_stop: 1300.4,
+        gallons_delivered: 300
+      })
+    ).toBeNull()
+  })
+
+  it('flags a mismatch beyond tolerance', () => {
+    const issue = validateSlipMeter({
+      meter_start: 1000,
+      meter_stop: 1300,
+      gallons_delivered: 250
+    })
+    expect(issue).toMatch(/Meter math/)
+  })
+
+  it('flags a stop reading lower than the start reading', () => {
+    const issue = validateSlipMeter({
+      meter_start: 1300,
+      meter_stop: 1000,
+      gallons_delivered: 300
+    })
+    expect(issue).toBe('Meter stop is lower than meter start')
+  })
+
+  it('returns null when readings are incomplete (nothing to check yet)', () => {
+    expect(
+      validateSlipMeter({
+        meter_start: null,
+        meter_stop: null,
+        gallons_delivered: null
+      })
+    ).toBeNull()
+    expect(
+      validateSlipMeter({
+        meter_start: 1000,
+        meter_stop: 1300,
+        gallons_delivered: null
+      })
+    ).toBeNull()
+  })
+})

--- a/frontend/components/invoice-slips/invoice-slip-review.tsx
+++ b/frontend/components/invoice-slips/invoice-slip-review.tsx
@@ -1,0 +1,266 @@
+'use client'
+
+import { CustomerCombobox } from '@/components/invoicing/customer-combobox'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  type ReviewInvoiceSlip,
+  toNumber
+} from '@/hooks/use-invoice-slip-import'
+import { cn } from '@/lib/utils'
+import type { CustomerRow } from '@/repositories/customers.repo'
+import {
+  FUEL_TYPE_LABELS,
+  type TicketFuelType
+} from '@/repositories/invoices.repo'
+import { AlertTriangle, FileText, Info, X } from 'lucide-react'
+import { validateSlipMeter } from './slip-validation'
+
+interface InvoiceSlipReviewProps {
+  slip: ReviewInvoiceSlip
+  customers: CustomerRow[]
+  onChange: (slip: ReviewInvoiceSlip) => void
+  onRemove: () => void
+}
+
+const FUEL_OPTIONS: { value: TicketFuelType; label: string }[] = Object.entries(
+  FUEL_TYPE_LABELS
+).map(([value, label]) => ({ value: value as TicketFuelType, label }))
+
+function meterMathIssue(slip: ReviewInvoiceSlip): string | null {
+  return validateSlipMeter({
+    meter_start: toNumber(slip.meter_start),
+    meter_stop: toNumber(slip.meter_stop),
+    gallons_delivered: toNumber(slip.gallons_delivered)
+  })
+}
+
+export function InvoiceSlipReview({
+  slip,
+  customers,
+  onChange,
+  onRemove
+}: InvoiceSlipReviewProps) {
+  function patch(p: Partial<ReviewInvoiceSlip>) {
+    onChange({ ...slip, ...p })
+  }
+
+  const mathIssue = meterMathIssue(slip)
+  const hasTankReadings = [
+    slip.tank_reading_before_left,
+    slip.tank_reading_before_right,
+    slip.tank_reading_before_center,
+    slip.tank_reading_before_total,
+    slip.tank_reading_after_left,
+    slip.tank_reading_after_right,
+    slip.tank_reading_after_center,
+    slip.tank_reading_after_total
+  ].some((v) => v.trim() !== '')
+
+  return (
+    <Card className="p-4 space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2 flex-wrap">
+          <FileText className="w-5 h-5 text-amber-400" />
+          <span className="font-semibold text-lg">
+            Invoice slip {slip.invoice_number || '?'}
+          </span>
+          <Badge variant="secondary">Paper book</Badge>
+          {!slip.invoice_number && (
+            <span className="flex items-center gap-1 text-xs text-destructive">
+              <AlertTriangle className="w-3 h-3" /> 5-digit serial not read —
+              enter manually
+            </span>
+          )}
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onRemove}
+          title="Discard this slip"
+        >
+          <X className="w-4 h-4" />
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">
+            Invoice # (red serial)
+          </Label>
+          <Input
+            value={slip.invoice_number}
+            onChange={(e) => patch({ invoice_number: e.target.value.trim() })}
+            className="h-8 text-xs font-mono"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Date</Label>
+          <Input
+            type="date"
+            value={slip.slip_date ?? ''}
+            onChange={(e) => patch({ slip_date: e.target.value || null })}
+            className="h-8 text-xs"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Aircraft No.</Label>
+          <Input
+            value={slip.aircraft_no}
+            onChange={(e) =>
+              patch({ aircraft_no: e.target.value.toUpperCase().trim() })
+            }
+            className="h-8 text-xs font-mono font-semibold"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Aircraft Type</Label>
+          <Input
+            value={slip.aircraft_type}
+            onChange={(e) =>
+              patch({ aircraft_type: e.target.value.toUpperCase() })
+            }
+            className="h-8 text-xs"
+          />
+        </div>
+        <div className="space-y-1 col-span-2">
+          <Label className="text-xs text-muted-foreground">Fuel type</Label>
+          <select
+            value={slip.fuel_type}
+            onChange={(e) =>
+              patch({ fuel_type: e.target.value as TicketFuelType })
+            }
+            className="h-8 w-full rounded-md border border-input bg-transparent px-2 text-xs focus:outline-none focus:border-primary"
+          >
+            {FUEL_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <Label className="text-xs text-muted-foreground">
+          Name (customer / airline)
+        </Label>
+        <CustomerCombobox
+          customers={customers}
+          customerId={slip.customer_id}
+          customerName={slip.customer_name}
+          onChange={(customerId, customerName) =>
+            patch({ customer_id: customerId, customer_name: customerName })
+          }
+        />
+      </div>
+
+      <div className="space-y-1">
+        <Label className="text-xs text-muted-foreground">Address</Label>
+        <Input
+          value={slip.address}
+          onChange={(e) => patch({ address: e.target.value })}
+          className="h-8 text-xs"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">
+            Meter start (less)
+          </Label>
+          <Input
+            value={slip.meter_start}
+            onChange={(e) => patch({ meter_start: e.target.value })}
+            className="h-8 text-xs font-mono"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">Meter stop</Label>
+          <Input
+            value={slip.meter_stop}
+            onChange={(e) => patch({ meter_stop: e.target.value })}
+            className="h-8 text-xs font-mono"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">
+            Gallons delivered
+          </Label>
+          <Input
+            value={slip.gallons_delivered}
+            onChange={(e) => patch({ gallons_delivered: e.target.value })}
+            className="h-8 text-xs font-mono"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">
+            Price / gal <span className="text-amber-400">(not on slip)</span>
+          </Label>
+          <Input
+            value={slip.price_per_gallon}
+            onChange={(e) => patch({ price_per_gallon: e.target.value })}
+            placeholder="0.00"
+            className="h-8 text-xs font-mono"
+          />
+        </div>
+      </div>
+
+      {mathIssue && (
+        <div className="flex items-center gap-1 text-xs text-amber-400">
+          <AlertTriangle className="w-3 h-3" /> {mathIssue}
+        </div>
+      )}
+
+      {hasTankReadings && (
+        <div className="space-y-2 rounded-lg border border-border p-3">
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <Info className="w-3 h-3" /> Per-tank readings (
+            {slip.tank_reading_unit || 'unit?'})
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            {(
+              [
+                ['tank_reading_before_left', 'Before L'],
+                ['tank_reading_before_center', 'Before C'],
+                ['tank_reading_before_right', 'Before R'],
+                ['tank_reading_before_total', 'Before T'],
+                ['tank_reading_after_left', 'After L'],
+                ['tank_reading_after_center', 'After C'],
+                ['tank_reading_after_right', 'After R'],
+                ['tank_reading_after_total', 'After T']
+              ] as const
+            ).map(([key, label]) => (
+              <div key={key} className="space-y-1">
+                <Label className="text-xs text-muted-foreground">{label}</Label>
+                <Input
+                  value={slip[key]}
+                  onChange={(e) =>
+                    patch({
+                      [key]: e.target.value
+                    } as Partial<ReviewInvoiceSlip>)
+                  }
+                  className="h-8 text-xs font-mono"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {slip.notes && (
+        <div
+          className={cn(
+            'flex items-start gap-1 text-xs rounded-md p-2',
+            'bg-muted/50 text-muted-foreground'
+          )}
+        >
+          <Info className="w-3 h-3 mt-0.5 shrink-0" /> {slip.notes}
+        </div>
+      )}
+    </Card>
+  )
+}

--- a/frontend/components/invoice-slips/slip-validation.ts
+++ b/frontend/components/invoice-slips/slip-validation.ts
@@ -1,0 +1,27 @@
+/**
+ * Sanity check for an invoice slip's meter block, mirroring
+ * truck-sheets/reading-validation.ts's meter-math check: gallons delivered
+ * should equal meter stop minus meter start.
+ */
+
+const MATH_TOLERANCE_GAL = 1.0
+
+export function validateSlipMeter(input: {
+  meter_start: number | null
+  meter_stop: number | null
+  gallons_delivered: number | null
+}): string | null {
+  const {
+    meter_start: start,
+    meter_stop: stop,
+    gallons_delivered: delivered
+  } = input
+  if (start == null || stop == null) return null
+  if (stop < start) return 'Meter stop is lower than meter start'
+  if (delivered == null) return null
+  const delta = stop - start
+  if (Math.abs(delta - delivered) > MATH_TOLERANCE_GAL) {
+    return `Meter math: stop − start = ${delta.toFixed(1)} gal but gallons delivered says ${delivered}`
+  }
+  return null
+}

--- a/frontend/components/navigation.tsx
+++ b/frontend/components/navigation.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useAuth } from '@/providers/auth-provider'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -9,6 +8,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import { useAuth } from '@/providers/auth-provider'
 import { Moon, Sun, User } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
@@ -20,6 +20,7 @@ const navigation = [
   { name: 'Fuel Farm', href: '/fuel-farm' },
   { name: 'Truck Sheets', href: '/truck-sheets' },
   { name: 'Invoicing', href: '/invoicing' },
+  { name: 'Document Intake', href: '/document-intake' },
   { name: 'Equipment', href: '/equipment' },
   { name: 'Line Schedule', href: '/line-schedule' },
   { name: 'Training', href: '/training' },
@@ -46,7 +47,10 @@ export function Navigation({ theme = 'dark', onThemeChange }: NavigationProps) {
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex h-12 items-center justify-between">
           <div className="flex items-center space-x-6">
-            <Link href="/" className="flex items-center gap-2 text-lg font-bold text-foreground">
+            <Link
+              href="/"
+              className="flex items-center gap-2 text-lg font-bold text-foreground"
+            >
               <img
                 src="/fbo-manager-logo.png"
                 alt="Logo"
@@ -62,10 +66,11 @@ export function Navigation({ theme = 'dark', onThemeChange }: NavigationProps) {
                 <Link
                   key={item.name}
                   href={item.href}
-                  className={`text-sm font-medium ${isActive
-                    ? 'text-primary'
-                    : 'text-muted-foreground hover:text-foreground'
-                    }`}
+                  className={`text-sm font-medium ${
+                    isActive
+                      ? 'text-primary'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
                 >
                   {item.name}
                 </Link>

--- a/frontend/hooks/__tests__/use-invoice-slip-import.test.ts
+++ b/frontend/hooks/__tests__/use-invoice-slip-import.test.ts
@@ -1,0 +1,81 @@
+import {
+  type ExtractedInvoiceSlip,
+  toNumber,
+  toReviewSlip,
+  toTransactionFuelType
+} from '@/hooks/use-invoice-slip-import'
+import { describe, expect, it } from 'vitest'
+
+const baseExtraction: ExtractedInvoiceSlip = {
+  invoice_number: '21483',
+  slip_date: '2026-07-04',
+  aircraft_no: 'N116FE',
+  aircraft_type: 'B737',
+  customer_name: 'Life Flight',
+  address: '',
+  meter_start: '1000',
+  meter_stop: '1300',
+  gallons_delivered: '300',
+  tank_reading_unit: '',
+  tank_reading_before_left: '',
+  tank_reading_before_right: '',
+  tank_reading_before_center: '',
+  tank_reading_before_total: '',
+  tank_reading_after_left: '',
+  tank_reading_after_right: '',
+  tank_reading_after_center: '',
+  tank_reading_after_total: '',
+  notes: ''
+}
+
+describe('toNumber', () => {
+  it('parses plain numeric strings', () => {
+    expect(toNumber('300')).toBe(300)
+  })
+
+  it('strips thousands separators and spaces', () => {
+    expect(toNumber('1,249')).toBe(1249)
+    expect(toNumber('1 249')).toBe(1249)
+  })
+
+  it('returns null for empty or non-numeric input', () => {
+    expect(toNumber('')).toBeNull()
+    expect(toNumber('T/O')).toBeNull()
+  })
+})
+
+describe('toTransactionFuelType', () => {
+  it('maps jet_a straight through', () => {
+    expect(toTransactionFuelType('jet_a')).toBe('jet_a')
+  })
+
+  it('collapses both avgas grades to the single fuel_transaction avgas value', () => {
+    expect(toTransactionFuelType('avgas_100')).toBe('avgas')
+    expect(toTransactionFuelType('avgas_80')).toBe('avgas')
+  })
+
+  it('has no fuel_transaction equivalent for unleaded — returns null rather than guessing', () => {
+    expect(toTransactionFuelType('unleaded')).toBeNull()
+  })
+})
+
+describe('toReviewSlip', () => {
+  it('seeds editable review defaults not present on the raw extraction', () => {
+    const file = new File(['x'], 'slip.jpg', { type: 'image/jpeg' })
+    const review = toReviewSlip(file, baseExtraction)
+
+    expect(review.include).toBe(true)
+    expect(review.file).toBe(file)
+    expect(review.fuel_type).toBe('jet_a')
+    expect(review.price_per_gallon).toBe('') // not on the physical slip — must be filled in manually
+    expect(review.customer_id).toBeNull()
+    expect(review.invoice_number).toBe('21483')
+  })
+
+  it('assigns each review slip a distinct local id', () => {
+    const file = new File(['x'], 'slip.jpg', { type: 'image/jpeg' })
+    const a = toReviewSlip(file, baseExtraction)
+    const b = toReviewSlip(file, baseExtraction)
+    expect(a.id).not.toBe(b.id)
+  })
+})

--- a/frontend/hooks/use-document-classify.ts
+++ b/frontend/hooks/use-document-classify.ts
@@ -1,0 +1,27 @@
+'use client'
+
+import type {
+  ClassifyResult,
+  DocClassification
+} from '@/app/api/ocr/classify-document/route'
+import { useMutation } from '@tanstack/react-query'
+
+export type { ClassifyResult, DocClassification }
+
+export function useClassifyDocument() {
+  return useMutation({
+    mutationFn: async (file: File): Promise<ClassifyResult> => {
+      const form = new FormData()
+      form.append('file', file)
+      const res = await fetch('/api/ocr/classify-document', {
+        method: 'POST',
+        body: form
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: 'Request failed' }))
+        throw new Error(err.error ?? 'Classification failed')
+      }
+      return res.json()
+    }
+  })
+}

--- a/frontend/hooks/use-invoice-slip-import.ts
+++ b/frontend/hooks/use-invoice-slip-import.ts
@@ -1,0 +1,204 @@
+'use client'
+
+import type { ExtractedInvoiceSlip } from '@/app/api/ocr/invoice-slip/route'
+import { invoiceKeys } from '@/hooks/use-invoices'
+import { transactionKeys } from '@/hooks/use-transactions'
+import { createClient } from '@/lib/supabase/client'
+import {
+  type TicketFuelType,
+  createInvoice
+} from '@/repositories/invoices.repo'
+import { uploadScannedDocument } from '@/repositories/scanned-documents.repo'
+import {
+  createTransaction,
+  updateTankReadings
+} from '@/repositories/transactions.repo'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+export type { ExtractedInvoiceSlip }
+export type { TicketFuelType }
+
+export interface ReviewInvoiceSlip extends ExtractedInvoiceSlip {
+  id: string // local key for editing
+  include: boolean
+  /** The original photo/PDF — persisted to Storage on import. */
+  file: File
+  fuel_type: TicketFuelType
+  /** Not printed on the slip; the line tech doesn't know pricing at the ramp. Must be filled in during review. */
+  price_per_gallon: string
+  customer_id: number | null
+}
+
+let localId = 0
+function nextId(prefix: string): string {
+  localId += 1
+  return `${prefix}-${localId}`
+}
+
+export function toNumber(v: string): number | null {
+  const n = Number.parseFloat(String(v).replace(/[, ]/g, ''))
+  return Number.isFinite(n) ? n : null
+}
+
+/** fuel_transaction.fuel_type only knows jet_a/jet_a_plus/avgas — invoice line items distinguish 100LL/80/unleaded separately. */
+export function toTransactionFuelType(
+  fuel: TicketFuelType
+): 'jet_a' | 'avgas' | null {
+  if (fuel === 'jet_a') return 'jet_a'
+  if (fuel === 'avgas_100' || fuel === 'avgas_80') return 'avgas'
+  return null
+}
+
+export function toReviewSlip(
+  file: File,
+  extraction: ExtractedInvoiceSlip
+): ReviewInvoiceSlip {
+  return {
+    ...extraction,
+    id: nextId('slip'),
+    include: true,
+    file,
+    fuel_type: 'jet_a',
+    price_per_gallon: '',
+    customer_id: null
+  }
+}
+
+export function useInvoiceSlipExtract() {
+  return useMutation({
+    mutationFn: async (file: File): Promise<ExtractedInvoiceSlip> => {
+      const form = new FormData()
+      form.append('file', file)
+      const res = await fetch('/api/ocr/invoice-slip', {
+        method: 'POST',
+        body: form
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: 'Request failed' }))
+        throw new Error(err.error ?? 'Extraction failed')
+      }
+      return res.json()
+    }
+  })
+}
+
+function hasAnyTankReading(slip: ReviewInvoiceSlip): boolean {
+  return [
+    slip.tank_reading_before_left,
+    slip.tank_reading_before_right,
+    slip.tank_reading_before_center,
+    slip.tank_reading_before_total,
+    slip.tank_reading_after_left,
+    slip.tank_reading_after_right,
+    slip.tank_reading_after_center,
+    slip.tank_reading_after_total
+  ].some((v) => v.trim() !== '')
+}
+
+export function useInvoiceSlipCommit() {
+  const db = createClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (slips: ReviewInvoiceSlip[]) => {
+      const created: number[] = []
+
+      for (const slip of slips) {
+        if (!slip.invoice_number || !slip.aircraft_no || !slip.customer_name) {
+          throw new Error(
+            'Each slip needs the 5-digit invoice number, aircraft number, and customer name before import'
+          )
+        }
+
+        // 1. The dispatch record. Invoice slips carry no truck number (unlike
+        //    truck sheets), so there is nothing to reconcile against an
+        //    existing fuel_truck/truck_sheet — this always creates a fresh
+        //    fuel_transaction rather than going through recordFuelingEvent.
+        const transaction = await createTransaction(db, {
+          ticket_number: `SLIP-${slip.invoice_number}`,
+          tail_number: slip.aircraft_no,
+          customer_name: slip.customer_name,
+          fuel_type: toTransactionFuelType(slip.fuel_type),
+          gallons_delivered: toNumber(slip.gallons_delivered),
+          progress: 'completed',
+          source: 'manual'
+        })
+
+        if (hasAnyTankReading(slip)) {
+          await updateTankReadings(db, transaction.id, {
+            before_left: toNumber(slip.tank_reading_before_left),
+            before_right: toNumber(slip.tank_reading_before_right),
+            before_center: toNumber(slip.tank_reading_before_center),
+            before_total: toNumber(slip.tank_reading_before_total),
+            after_left: toNumber(slip.tank_reading_after_left),
+            after_right: toNumber(slip.tank_reading_after_right),
+            after_center: toNumber(slip.tank_reading_after_center),
+            after_total: toNumber(slip.tank_reading_after_total),
+            unit: slip.tank_reading_unit || undefined
+          })
+        }
+
+        // 2. The invoice. Saved as a DRAFT — price per gallon is not on the
+        //    physical slip and defaults to 0 until front desk fills it in, so
+        //    this must never auto-finalize as a $0 paid invoice.
+        const invoice = await createInvoice(db, {
+          header: {
+            invoiceNumber: slip.invoice_number,
+            invoiceDate:
+              slip.slip_date || new Date().toISOString().slice(0, 10),
+            customerId: slip.customer_id,
+            customerName: slip.customer_name,
+            station: null,
+            tailNumber: slip.aircraft_no,
+            aircraftType: slip.aircraft_type || null,
+            flightId: null,
+            paymentMethod: null,
+            checkNumber: null,
+            salesmanInitials: null,
+            notes: slip.notes || null,
+            // Guaranteed by doc_type, not inferred from the number's shape —
+            // every invoice-slip import IS a paper-book invoice.
+            numberSource: 'paper_book'
+          },
+          fuelLine: {
+            fuelTransactionId: transaction.id,
+            fuelType: slip.fuel_type,
+            quantityGallons: toNumber(slip.gallons_delivered) ?? 0,
+            pricePerGallon: toNumber(slip.price_per_gallon) ?? 0,
+            density: null,
+            requestedAmount: null,
+            serviceTime: null,
+            readings: []
+          },
+          serviceLines: [],
+          finalize: false
+        })
+
+        // 3. Persist the original scan (private 'scans' bucket), best-effort:
+        //    mirrors use-truck-sheet-import.ts — a storage hiccup must not
+        //    roll back a successful invoice/transaction import.
+        try {
+          await uploadScannedDocument(db, {
+            docType: 'invoice_slip',
+            file: slip.file,
+            filename: slip.file.name,
+            invoiceId: invoice.id
+          })
+        } catch (err) {
+          console.error(
+            `Failed to persist original scan "${slip.file.name}" for invoice ${invoice.id}:`,
+            err
+          )
+        }
+
+        created.push(invoice.id)
+      }
+
+      return created
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: invoiceKeys.all })
+      queryClient.invalidateQueries({ queryKey: transactionKeys.all })
+    }
+  })
+}


### PR DESCRIPTION
## Summary

Ted has ~a week of unprocessed scans (truck sheets and airline "invoice slip" receipts) and needs a way to dump both, in any file shape (multi-page PDFs or individual photos), into one place. This extends the existing truck-sheet OCR pipeline (`app/api/ocr/truck-sheet/route.ts`, `use-truck-sheet-import.ts`, `truck-sheet-review.tsx`) with a second document type and a general intake surface.

**New:**
- `app/api/ocr/invoice-slip/route.ts` — Claude vision extraction for the carbon-copy paper-book invoice slip: Aircraft No./Type, Date, Name, Address, meter stop/start, gallons delivered, 5-digit red serial invoice number, and optional per-tank before/after readings (737 L/C/R, E175 L/R/T) for airline fuelings.
- `app/api/ocr/classify-document/route.ts` — classifies an uploaded file as `truck_sheet | invoice_slip | unrecognized` with a single Claude vision call.
- `hooks/use-invoice-slip-import.ts` + `components/invoice-slips/*` — review/commit flow mirroring the truck-sheet one.
- `app/document-intake/page.tsx` (+ nav entry) — one page that accepts a mixed batch of PDFs/photos, classifies and routes each to the right extraction queue, with an explicit manual-triage list for anything unrecognized (pick a type or discard — never silently dropped/guessed).

**No schema changes.** `scanned_documents.doc_type` already includes `'invoice_slip'` and `invoices`/`invoice_line_items` already support the `fuel_transaction_id` billing link from the prior fuel-invoicing-workflow migration — this pass only adds the OCR route, hook, and UI that migration's own doc-comment said were "designed, not yet built."

## Judgment calls to confirm/overrule (per your ask — flagging rather than silently baking in)

1. **"Airline receipts" → `invoice_slip`.** Your message mentioned "airline receipts (for meter readings)"; I've mapped this to the existing `invoice_slip` doc_type per the domain memory (carbon-copy paper-book invoice, 5-digit red serial). Flag if you meant something else.
2. **Vision-classification instead of a trained model.** You said "we need to train this somehow" but didn't finish the thought. I used the same technique the truck-sheet route already uses to classify each row (a single Claude vision call, zero training data, zero separate model) rather than building/training a dedicated classifier. Zero new infra, proven pattern. If you actually want a trained classifier (e.g. for cost/latency at scale), that's a bigger, separate effort.
3. **Classification/extraction operate per uploaded FILE, not per PDF page.** A multi-page PDF is treated as one logical document spanning pages (same assumption the truck-sheet route already makes). If a single PDF genuinely interleaves *different* documents on different pages (e.g. some pages a truck sheet, other pages an unrelated invoice slip), this pass does not split it automatically — that's a real limitation, not silently "solved." Flag if this is common enough to need real page-splitting.
4. **Invoice slip has no truck number.** Unlike truck-sheet import (which reconciles into an existing `fuel_truck`/`truck_sheet`), an invoice slip never records which truck fueled the aircraft. So invoice-slip commit creates a `fuel_transaction` directly (`source: 'manual'`, ticket number `SLIP-{invoice_number}`) and bills it via `createInvoice`'s existing `fuelTransactionId` path — it never touches `truck_meter_readings`/`truck_sheets`.
5. **Invoices import as drafts.** Price per gallon is not printed on the slip (only quantities), so it defaults to 0 and must be filled in during review; to avoid ever silently finalizing a $0 "paid" invoice, `finalize: false` always, regardless of payment method.
6. **`number_source` forced to `'paper_book'`**, not inferred from the number's shape — every invoice-slip import IS a paper-book invoice by definition of the doc type.
7. Unrecognized files get a manual triage list (pick `truck_sheet`/`invoice_slip` to retry, or discard) rather than being dropped or guessed.

## Testing

Added vitest coverage for all new pure logic (no DB required): OCR response normalization for both new routes, `toNumber`/`toTransactionFuelType`/`toReviewSlip` in the import hook, and the invoice-slip meter-math check. Verified behavior directly with `tsx` sanity scripts and `tsc --noEmit` (both clean) since **this sandbox has no reachable Docker/local Supabase stack** — the vitest project's global setup gates every test file on a live local Supabase REST API, so I could not execute `pnpm test` here (pre-existing environment constraint, not introduced by this change). Please run `pnpm supabase:start && pnpm test` in a normal dev environment before merge to execute the new test files for real.

Also ran a full `next build` (with dummy env vars) — compiles clean, both new API routes and `/document-intake` show up in the route manifest alongside the existing OCR/truck-sheet routes.

## Test plan

- [ ] `pnpm supabase:start && pnpm test` — confirm the new vitest files pass for real
- [ ] Manually upload a real truck-sheet photo and a real invoice-slip photo through `/document-intake`, confirm each routes to the correct review queue
- [ ] Confirm an invoice-slip import creates a draft invoice + `fuel_transaction` with no `truck_meter_readings` row, and appears correctly in `/invoicing`
- [ ] Confirm an ambiguous/blank scan lands in the "needs manual triage" list instead of silently failing